### PR TITLE
Add expense form and dashboard integration

### DIFF
--- a/travel_planner_app/lib/screens/dashboard_screen.dart
+++ b/travel_planner_app/lib/screens/dashboard_screen.dart
@@ -1,10 +1,16 @@
 import 'package:flutter/material.dart';
 import '../models/trip.dart';
 import '../models/expense.dart';
+import 'expense_form_screen.dart';
 
-class DashboardScreen extends StatelessWidget {
-  DashboardScreen({super.key});
+class DashboardScreen extends StatefulWidget {
+  const DashboardScreen({super.key});
 
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
   final Trip trip = Trip(
     id: 't1',
     name: 'Italy Trip',
@@ -14,14 +20,26 @@ class DashboardScreen extends StatelessWidget {
     currency: 'EUR',
   );
 
-  final List<Expense> expenses = [
-    Expense(id: 'e1', tripId: 't1', title: 'Flight', amount: 300, category: 'Transport', date: DateTime.now()),
-    Expense(id: 'e2', tripId: 't1', title: 'Pizza Dinner', amount: 40, category: 'Food', date: DateTime.now()),
-  ];
+  final List<Expense> _expenses = [];
+
+  void _addExpense(String title, double amount, String category) {
+    setState(() {
+      _expenses.add(
+        Expense(
+          id: DateTime.now().toString(),
+          tripId: 't1',
+          title: title,
+          amount: amount,
+          category: category,
+          date: DateTime.now(),
+        ),
+      );
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-    double totalSpent = expenses.fold(0, (sum, e) => sum + e.amount);
+    double totalSpent = _expenses.fold(0, (sum, e) => sum + e.amount);
     double remaining = trip.initialBudget - totalSpent;
 
     return Scaffold(
@@ -37,9 +55,9 @@ class DashboardScreen extends StatelessWidget {
             const SizedBox(height: 20),
             Expanded(
               child: ListView.builder(
-                itemCount: expenses.length,
+                itemCount: _expenses.length,
                 itemBuilder: (ctx, i) {
-                  final e = expenses[i];
+                  final e = _expenses[i];
                   return ListTile(
                     title: Text(e.title),
                     subtitle: Text('${e.category} • ${e.amount} ${trip.currency}'),
@@ -50,6 +68,16 @@ class DashboardScreen extends StatelessWidget {
             )
           ],
         ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        child: const Icon(Icons.add),
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => ExpenseFormScreen(onAddExpense: _addExpense),
+            ),
+          );
+        },
       ),
     );
   }

--- a/travel_planner_app/lib/screens/expense_form_screen.dart
+++ b/travel_planner_app/lib/screens/expense_form_screen.dart
@@ -1,13 +1,66 @@
 import 'package:flutter/material.dart';
 
-class ExpenseFormScreen extends StatelessWidget {
-  const ExpenseFormScreen({super.key});
+class ExpenseFormScreen extends StatefulWidget {
+  final Function(String, double, String) onAddExpense;
+
+  ExpenseFormScreen({required this.onAddExpense});
+
+  @override
+  State<ExpenseFormScreen> createState() => _ExpenseFormScreenState();
+}
+
+class _ExpenseFormScreenState extends State<ExpenseFormScreen> {
+  final _titleController = TextEditingController();
+  final _amountController = TextEditingController();
+  String _selectedCategory = 'Food';
+
+  void _submitForm() {
+    final title = _titleController.text;
+    final amount = double.tryParse(_amountController.text) ?? 0;
+
+    if (title.isEmpty || amount <= 0) return;
+
+    widget.onAddExpense(title, amount, _selectedCategory);
+    Navigator.of(context).pop(); // go back to dashboard
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Add Expense')),
-      body: const Center(child: Text('Expense form coming soon')),
+      appBar: AppBar(title: Text('Add Expense')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _titleController,
+              decoration: InputDecoration(labelText: 'Expense Title'),
+            ),
+            TextField(
+              controller: _amountController,
+              decoration: InputDecoration(labelText: 'Amount (€)'),
+              keyboardType: TextInputType.numberWithOptions(decimal: true),
+            ),
+            DropdownButton<String>(
+              value: _selectedCategory,
+              items: ['Food', 'Transport', 'Lodging', 'Other']
+                  .map((cat) => DropdownMenuItem(
+                        value: cat,
+                        child: Text(cat),
+                      ))
+                  .toList(),
+              onChanged: (val) {
+                if (val != null) setState(() => _selectedCategory = val);
+              },
+            ),
+            SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _submitForm,
+              child: Text('Save Expense'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- implement interactive expense form screen allowing users to enter title, amount, and category
- convert dashboard to stateful widget and display added expenses

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ce330f23483278b1a140cf93309c8