### PR TITLE
Add Hive offline storage for expenses

### DIFF
--- a/travel_planner_app/lib/main.dart
+++ b/travel_planner_app/lib/main.dart
@@ -1,10 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'models/expense.dart';
 import 'screens/dashboard_screen.dart';
 
-void main() {
-  runApp(MaterialApp(
-    title: 'Travel Planner',
-    home: DashboardScreen(),
-    debugShowCheckedModeBanner: false,
-  ));
+class TravelPlannerApp extends StatelessWidget {
+  const TravelPlannerApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'Travel Planner',
+      home: DashboardScreen(),
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Hive.initFlutter();
+  Hive.registerAdapter(ExpenseAdapter());
+  await Hive.openBox<Expense>('expensesBox');
+
+  runApp(const TravelPlannerApp());
 }

--- a/travel_planner_app/lib/models/expense.dart
+++ b/travel_planner_app/lib/models/expense.dart
@@ -1,10 +1,26 @@
-class Expense {
-  final String id;
-  final String tripId;
-  final String title;
-  final double amount;
-  final String category;
-  final DateTime date;
+import 'package:hive/hive.dart';
+
+part 'expense.g.dart';
+
+@HiveType(typeId: 0)
+class Expense extends HiveObject {
+  @HiveField(0)
+  String id;
+
+  @HiveField(1)
+  String tripId;
+
+  @HiveField(2)
+  String title;
+
+  @HiveField(3)
+  double amount;
+
+  @HiveField(4)
+  String category;
+
+  @HiveField(5)
+  DateTime date;
 
   Expense({
     required this.id,

--- a/travel_planner_app/lib/models/expense.g.dart
+++ b/travel_planner_app/lib/models/expense.g.dart
@@ -1,0 +1,52 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'expense.dart';
+
+class ExpenseAdapter extends TypeAdapter<Expense> {
+  @override
+  final int typeId = 0;
+
+  @override
+  Expense read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Expense(
+      id: fields[0] as String,
+      tripId: fields[1] as String,
+      title: fields[2] as String,
+      amount: fields[3] as double,
+      category: fields[4] as String,
+      date: fields[5] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Expense obj) {
+    writer
+      ..writeByte(6)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.tripId)
+      ..writeByte(2)
+      ..write(obj.title)
+      ..writeByte(3)
+      ..write(obj.amount)
+      ..writeByte(4)
+      ..write(obj.category)
+      ..writeByte(5)
+      ..write(obj.date);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ExpenseAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/travel_planner_app/lib/screens/dashboard_screen.dart
+++ b/travel_planner_app/lib/screens/dashboard_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import '../models/trip.dart';
 import '../models/expense.dart';
 import 'expense_form_screen.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:uuid/uuid.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -20,21 +22,29 @@ class _DashboardScreenState extends State<DashboardScreen> {
     currency: 'EUR',
   );
 
-  final List<Expense> _expenses = [];
+  late List<Expense> _expenses;
+  late Box<Expense> _expensesBox;
 
   void _addExpense(String title, double amount, String category) {
+    final newExpense = Expense(
+      id: const Uuid().v4(),
+      tripId: 't1',
+      title: title,
+      amount: amount,
+      category: category,
+      date: DateTime.now(),
+    );
     setState(() {
-      _expenses.add(
-        Expense(
-          id: DateTime.now().toString(),
-          tripId: 't1',
-          title: title,
-          amount: amount,
-          category: category,
-          date: DateTime.now(),
-        ),
-      );
+      _expenses.add(newExpense);
     });
+    _expensesBox.add(newExpense);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _expensesBox = Hive.box<Expense>('expensesBox');
+    _expenses = _expensesBox.values.toList();
   }
 
   @override

--- a/travel_planner_app/pubspec.yaml
+++ b/travel_planner_app/pubspec.yaml
@@ -34,6 +34,10 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+  path_provider: ^2.0.15
+  uuid: ^4.0.0
 
 dev_dependencies:
   flutter_test:
@@ -45,6 +49,8 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
+  build_runner: ^2.4.8
+  hive_generator: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary
- integrate Hive for offline expense storage
- update Expense model and generate Hive adapter
- persist and load expenses from local Hive box

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter packages pub run build_runner build` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce50aa2388327acdedc9a4b0397ff