### PR TITLE
Add app shell with active trip and group balances

### DIFF
--- a/travel_planner_app/lib/main.dart
+++ b/travel_planner_app/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'models/expense.dart';
-import 'screens/dashboard_screen.dart';
+import 'screens/app_shell.dart';
 
 class TravelPlannerApp extends StatelessWidget {
   const TravelPlannerApp({super.key});
@@ -47,7 +47,7 @@ class TravelPlannerApp extends StatelessWidget {
           ),
         ),
       ),
-      home: const DashboardScreen(),
+      home: const AppShell(),
     );
   }
 }

--- a/travel_planner_app/lib/models/group_balance.dart
+++ b/travel_planner_app/lib/models/group_balance.dart
@@ -1,0 +1,21 @@
+class GroupBalance {
+  final String from; // who owes
+  final String to; // who is owed
+  final double amount;
+  final String currency;
+
+  GroupBalance({
+    required this.from,
+    required this.to,
+    required this.amount,
+    required this.currency,
+  });
+
+  factory GroupBalance.fromJson(Map<String, dynamic> j) => GroupBalance(
+        from: j['from'] as String,
+        to: j['to'] as String,
+        amount: (j['amount'] as num).toDouble(),
+        currency: (j['currency'] ?? 'EUR') as String,
+      );
+}
+

--- a/travel_planner_app/lib/screens/app_shell.dart
+++ b/travel_planner_app/lib/screens/app_shell.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import '../models/trip.dart';
 import 'dashboard_screen.dart';
-import 'expense_form_screen.dart'; // your existing form
+import 'group_balance_screen.dart';
+import 'trip_picker_screen.dart';
 
 class AppShell extends StatefulWidget {
   const AppShell({super.key});
+
   @override
   State<AppShell> createState() => _AppShellState();
 }
@@ -11,45 +14,39 @@ class AppShell extends StatefulWidget {
 class _AppShellState extends State<AppShell> {
   int _index = 0;
 
+  // TODO: replace with your real trip selection persistence
+  Trip _activeTrip = Trip(
+    id: 't1',
+    name: 'Italy Trip',
+    startDate: DateTime(2025, 9, 1),
+    endDate: DateTime(2025, 9, 10),
+    initialBudget: 1500.0,
+    currency: 'EUR',
+    participants: const ['Rahul', 'Alex', 'Maya'],
+  );
+
+  void _setActiveTrip(Trip t) => setState(() => _activeTrip = t);
+
   @override
   Widget build(BuildContext context) {
-    final pages = const [
-      DashboardScreen(),
-      Placeholder(), // Trips screen (coming soon)
-      Placeholder(), // Settings (coming soon)
+    final pages = [
+      DashboardScreen(activeTrip: _activeTrip),
+      GroupBalanceScreen(activeTrip: _activeTrip),
+      TripPickerScreen(
+        current: _activeTrip,
+        onPick: (t) {
+          _setActiveTrip(t);
+          setState(() => _index = 0); // jump back to Dashboard
+        },
+      ),
     ];
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Travel Planner'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.account_balance_wallet_outlined),
-            onPressed: () {},
-          ),
-          const SizedBox(width: 4),
-        ],
-      ),
+      appBar: AppBar(title: Text(_activeTrip.name)),
       body: AnimatedSwitcher(
         duration: const Duration(milliseconds: 250),
         child: pages[_index],
       ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () {
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (_) => ExpenseFormScreen(
-                onAddExpense: (title, amount, category, paidBy, sharedWith) {
-                  // you already handle adding/saving; keep this wiring
-                },
-              ),
-            ),
-          );
-        },
-        icon: const Icon(Icons.add),
-        label: const Text('Add expense'),
-      ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       bottomNavigationBar: NavigationBar(
         selectedIndex: _index,
         onDestinationSelected: (i) => setState(() => _index = i),
@@ -60,17 +57,18 @@ class _AppShellState extends State<AppShell> {
             label: 'Dashboard',
           ),
           NavigationDestination(
+            icon: Icon(Icons.people_outline),
+            selectedIcon: Icon(Icons.people),
+            label: 'Balances',
+          ),
+          NavigationDestination(
             icon: Icon(Icons.public_outlined),
             selectedIcon: Icon(Icons.public),
             label: 'Trips',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.settings_outlined),
-            selectedIcon: Icon(Icons.settings),
-            label: 'Settings',
           ),
         ],
       ),
     );
   }
 }
+

--- a/travel_planner_app/lib/screens/dashboard_screen.dart
+++ b/travel_planner_app/lib/screens/dashboard_screen.dart
@@ -7,23 +7,15 @@ import '../models/trip.dart';
 import 'expense_form_screen.dart';
 
 class DashboardScreen extends StatefulWidget {
-  const DashboardScreen({super.key});
+  const DashboardScreen({super.key, required this.activeTrip});
+  final Trip activeTrip;
 
   @override
   State<DashboardScreen> createState() => _DashboardScreenState();
 }
 
 class _DashboardScreenState extends State<DashboardScreen> {
-  // ⛳️ replace with your active trip (later: select from Trip list)
-  final Trip trip = Trip(
-    id: 't1',
-    name: 'Italy Trip',
-    startDate: DateTime(2025, 9, 1),
-    endDate: DateTime(2025, 9, 10),
-    initialBudget: 1500.0,
-    currency: 'EUR',
-    participants: const ['Rahul'],
-  );
+  late Trip trip;
 
   late Box<Expense> _expensesBox;
   List<Expense> _expenses = []; // start empty to avoid first-build nulls
@@ -32,6 +24,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
   @override
   void initState() {
     super.initState();
+    trip = widget.activeTrip;
     _expensesBox = Hive.box<Expense>('expensesBox');
     // load cached first for instant UI, then try API
     _expenses = _expensesBox.values.toList();
@@ -98,17 +91,6 @@ class _DashboardScreenState extends State<DashboardScreen> {
     final categories = _categorySummaries(_expenses);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(trip.name),
-        centerTitle: true,
-        actions: [
-          IconButton(
-            tooltip: 'Refresh',
-            onPressed: _loadFromApi,
-            icon: const Icon(Icons.sync),
-          ),
-        ],
-      ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () {
           Navigator.of(context).push(

--- a/travel_planner_app/lib/screens/group_balance_screen.dart
+++ b/travel_planner_app/lib/screens/group_balance_screen.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import '../models/trip.dart';
+import '../models/group_balance.dart';
+import '../services/api_service.dart';
+
+class GroupBalanceScreen extends StatefulWidget {
+  final Trip activeTrip;
+  const GroupBalanceScreen({super.key, required this.activeTrip});
+
+  @override
+  State<GroupBalanceScreen> createState() => _GroupBalanceScreenState();
+}
+
+class _GroupBalanceScreenState extends State<GroupBalanceScreen> {
+  late Future<List<GroupBalance>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = ApiService.fetchGroupBalances(widget.activeTrip.id);
+  }
+
+  Future<void> _refresh() async {
+    setState(
+        () => _future = ApiService.fetchGroupBalances(widget.activeTrip.id));
+    await _future;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return RefreshIndicator(
+      onRefresh: _refresh,
+      child: FutureBuilder<List<GroupBalance>>(
+        future: _future,
+        builder: (context, snap) {
+          if (snap.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snap.hasError) {
+            return ListView(
+              children: [
+                const SizedBox(height: 100),
+                Icon(Icons.error_outline, size: 48, color: cs.error),
+                const SizedBox(height: 12),
+                const Center(child: Text('Couldn\'t load balances')),
+                const SizedBox(height: 8),
+                Center(
+                  child: Text('${snap.error}',
+                      style: Theme.of(context).textTheme.bodySmall),
+                ),
+                const SizedBox(height: 12),
+                Center(
+                  child: ElevatedButton.icon(
+                    onPressed: _refresh,
+                    icon: const Icon(Icons.refresh),
+                    label: const Text('Retry'),
+                  ),
+                ),
+              ],
+            );
+          }
+
+          final items = snap.data ?? [];
+          if (items.isEmpty) {
+            return ListView(
+              children: const [
+                SizedBox(height: 100),
+                Center(child: Text('No balances yet — add some expenses!')),
+              ],
+            );
+          }
+
+          return ListView.separated(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 100),
+            itemCount: items.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemBuilder: (context, i) {
+              final b = items[i];
+              final amt = b.amount.toStringAsFixed(2);
+              return Card(
+                child: ListTile(
+                  leading: CircleAvatar(
+                    backgroundColor: cs.primaryContainer,
+                    child: Icon(Icons.swap_horiz,
+                        color: cs.onPrimaryContainer),
+                  ),
+                  title: Text('${b.from} → ${b.to}',
+                      style: const TextStyle(fontWeight: FontWeight.w700)),
+                  subtitle: const Text('settlement'),
+                  trailing: Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: cs.secondaryContainer,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: Text('$amt ${b.currency}',
+                        style: TextStyle(
+                            color: cs.onSecondaryContainer,
+                            fontWeight: FontWeight.w800)),
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+

--- a/travel_planner_app/lib/screens/trip_picker_screen.dart
+++ b/travel_planner_app/lib/screens/trip_picker_screen.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import '../models/trip.dart';
+
+class TripPickerScreen extends StatelessWidget {
+  final Trip current;
+  final void Function(Trip) onPick;
+  const TripPickerScreen({super.key, required this.current, required this.onPick});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: fetch from API; for now demo two trips
+    final demo = [
+      current,
+      Trip(
+        id: 't2',
+        name: 'Spain Escape',
+        startDate: DateTime(2025, 10, 5),
+        endDate: DateTime(2025, 10, 12),
+        initialBudget: 1200,
+        currency: 'EUR',
+        participants: const ['Rahul', 'Alex'],
+      ),
+    ];
+
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 100),
+      itemCount: demo.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, i) {
+        final t = demo[i];
+        final isActive = t.id == current.id;
+        return Card(
+          child: ListTile(
+            title: Text(t.name, style: const TextStyle(fontWeight: FontWeight.w700)),
+            subtitle: Text('${t.startDate.toString().split(' ').first} → ${t.endDate.toString().split(' ').first} • ${t.currency}'),
+            trailing: isActive ? const Icon(Icons.check_circle, color: Colors.green) : null,
+            onTap: () => onPick(t),
+          ),
+        );
+      },
+    );
+  }
+}
+

--- a/travel_planner_app/lib/services/api_service.dart
+++ b/travel_planner_app/lib/services/api_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/expense.dart';
 import '../models/trip.dart';
+import '../models/group_balance.dart';
 
 class ApiService {
   static const String baseUrl = 'http://192.168.0.9:8080'; // 👈 Replace this
@@ -58,5 +59,15 @@ class ApiService {
     if (response.statusCode != 200 && response.statusCode != 201) {
       throw Exception('Failed to add trip');
     }
+  }
+
+  static Future<List<GroupBalance>> fetchGroupBalances(String tripId) async {
+    final uri = Uri.parse('$baseUrl/expenses/split/$tripId');
+    final res = await http.get(uri);
+    if (res.statusCode != 200) {
+      throw Exception('Split fetch failed: ${res.statusCode}');
+    }
+    final data = (jsonDecode(res.body) as List).cast<Map<String, dynamic>>();
+    return data.map(GroupBalance.fromJson).toList();
   }
 }


### PR DESCRIPTION
## Summary
- replace previous shell with stateful AppShell handling active trip and bottom nav
- add Splitwise-style group balance screen and trip picker
- wire API service and dashboard to new active trip flow

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d1e2d193083278a1a9930e4f2c176