### PR TITLE
Guard async setState and handle balance 404s

### DIFF
--- a/travel_planner_app/lib/screens/dashboard_screen.dart
+++ b/travel_planner_app/lib/screens/dashboard_screen.dart
@@ -37,6 +37,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
   Future<void> _loadFromApi() async {
     try {
       final remote = await ApiService.fetchExpenses(trip.id); // use real tripId
+      if (!mounted) return;
       setState(() {
         _expenses = remote;
       });
@@ -87,6 +88,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
       sharedWith: sharedWith,
     );
 
+    if (!mounted) return;
     setState(() => _expenses = [..._expenses, expense]);
     _expensesBox.add(expense);
     _convert();

--- a/travel_planner_app/lib/screens/group_balance_screen.dart
+++ b/travel_planner_app/lib/screens/group_balance_screen.dart
@@ -21,9 +21,10 @@ class _GroupBalanceScreenState extends State<GroupBalanceScreen> {
   }
 
   Future<void> _refresh() async {
-    setState(
-        () => _future = ApiService.fetchGroupBalances(widget.activeTrip.id));
-    await _future;
+    final fut = ApiService.fetchGroupBalances(widget.activeTrip.id);
+    if (!mounted) return;
+    setState(() => _future = fut);
+    await fut;
   }
 
   @override

--- a/travel_planner_app/lib/services/api_service.dart
+++ b/travel_planner_app/lib/services/api_service.dart
@@ -56,8 +56,9 @@ class ApiService {
   // ----- balances -----
   static Future<List<GroupBalance>> fetchGroupBalances(String tripId) async {
     final res = await http.get(Uri.parse('$baseUrl/balances/$tripId'));
+    if (res.statusCode == 404) return <GroupBalance>[];
     if (res.statusCode != 200) {
-      throw Exception('Split fetch failed: ${res.statusCode}');
+      throw Exception('Split fetch failed: ${res.statusCode} ${res.body}');
     }
     final data = (jsonDecode(res.body) as List).cast<Map<String, dynamic>>();
     return data.map(GroupBalance.fromJson).toList();


### PR DESCRIPTION
## Summary
- Guard `setState` calls with `mounted` in Dashboard to prevent updates after disposal
- Refactor GroupBalance refresh to avoid async work inside `setState`
- Return empty list when group balance API responds with 404

## Testing
- `dart format lib/screens/dashboard_screen.dart lib/screens/group_balance_screen.dart lib/services/api_service.dart` *(command not found: dart)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689d39bf98a483279d5f609a8bb1bbda