### PR TITLE
feat: add offline expense queue and CRUD

### DIFF
--- a/travel_planner_app/lib/models/expense.dart
+++ b/travel_planner_app/lib/models/expense.dart
@@ -54,9 +54,14 @@ class Expense extends HiveObject {
     'title': title,
     'amount': amount,
     'category': category,
-    'date': date.toIso8601String(),
+    'date': _yyyyMmDd(date),
     'paidBy': paidBy,
     'sharedWith': sharedWith,
-    'currency': currency, // <-- add
+    'currency': currency,
   };
+
+// ===== _yyyyMmDd helper start =====
+  String _yyyyMmDd(DateTime d) =>
+      '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+// ===== _yyyyMmDd helper end =====
 }

--- a/travel_planner_app/lib/screens/app_shell.dart
+++ b/travel_planner_app/lib/screens/app_shell.dart
@@ -33,6 +33,12 @@ class _AppShellState extends State<AppShell> {
     super.initState();
     _activeTrip = TripStorageService.loadLightweight();
 
+    // ===== App start: sync pending expenses start =====
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      widget.api.syncPendingExpensesIfOnline();
+    });
+    // ===== App start: sync pending expenses end =====
+
     // If no trip is selected yet, open the picker after first frame.
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (_activeTrip == null && mounted) {

--- a/travel_planner_app/lib/screens/dashboard_screen.dart
+++ b/travel_planner_app/lib/screens/dashboard_screen.dart
@@ -287,36 +287,14 @@ class _DashboardScreenState extends State<DashboardScreen> {
     await Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => ExpenseFormScreen(
+          api: widget.api,
           participants: participants,
           defaultCurrency: t.currency,
           availableCurrencies: availableCurrencies, // 👈 pass choices here
-          onSubmit: ({
-            required String title,
-            required double amount,
-            required String category,
-            required String paidBy,
-            required List<String> sharedWith,
-            required String currency, // <-- new param
-          }) async {
-            final e = Expense(
-              id: DateTime.now().toIso8601String(),
-              tripId: t.id,
-              title: title,
-              amount: amount,
-              category: category,
-              date: DateTime.now(),
-              paidBy: paidBy,
-              sharedWith: sharedWith,
-              currency : currency, // <-- new param
-            );
-            await _box.add(e); // local first (Hive)
-            setState(() => _expenses.insert(0, e));
-            await _recalcSpentInTripCurrency();
-            await _updateApproxHome();
-          },
         ),
       ),
     );
+    await _loadLocal();
   }
 
 

--- a/travel_planner_app/lib/screens/expenses_screen.dart
+++ b/travel_planner_app/lib/screens/expenses_screen.dart
@@ -21,13 +21,13 @@ class _ExpensesScreenState extends State<ExpensesScreen> {
     super.initState();
     _trip = TripStorageService.loadLightweight();
     // 1) show local instantly (if dashboard saved anything to Hive)
-    _future = _trip == null ? Future.value(<Expense>[]) : widget.api.fetchExpenses(_trip!.id);
+    _future = _trip == null ? Future.value(<Expense>[]) : widget.api.fetchExpensesOrCache(_trip!.id);
   }
 
   Future<void> _refresh() async {
     _trip = TripStorageService.loadLightweight();
     setState(() {
-      _future = _trip == null ? Future.value(<Expense>[]) : widget.api.fetchExpenses(_trip!.id);
+      _future = _trip == null ? Future.value(<Expense>[]) : widget.api.fetchExpensesOrCache(_trip!.id);
     });
     await _future;
   }
@@ -102,11 +102,20 @@ class _ExpensesScreenState extends State<ExpensesScreen> {
                 ],
               );
             }
+            final usingCache = widget.api.lastExpensesFromCache;
             return ListView.separated(
-              itemCount: expenses.length,
+              itemCount: expenses.length + (usingCache ? 1 : 0),
               separatorBuilder: (_, __) => const Divider(height: 1),
               itemBuilder: (_, i) {
-                final e = expenses[i];
+                if (usingCache && i == 0) {
+                  return Container(
+                    padding: const EdgeInsets.all(12),
+                    color: Theme.of(context).colorScheme.surfaceVariant,
+                    child: const Text('Showing cached expenses (offline or server unavailable). Pull to refresh.'),
+                  );
+                }
+                final idx = usingCache ? i - 1 : i;
+                final e = expenses[idx];
                 return ListTile(
                   title: Text(e.title),
                   subtitle: Text('${e.category} • ${e.paidBy}'),
@@ -116,7 +125,7 @@ class _ExpensesScreenState extends State<ExpensesScreen> {
                         await _editExpenseDialog(e);
                         await _refresh();
                       } else if (v == 'delete') {
-                        await widget.api.deleteExpense(e.id);
+                        await widget.api.deleteExpense(e);
                         await _refresh();
                       }
                     },

--- a/travel_planner_app/lib/services/local_expense_store.dart
+++ b/travel_planner_app/lib/services/local_expense_store.dart
@@ -1,0 +1,31 @@
+// lib/services/local_expense_store.dart
+
+// ===== LocalExpenseStore class start =====
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/expense.dart';
+
+class LocalExpenseStore {
+  static const _kExpensesByTripKeyPrefix = 'expenses_by_trip_'; // key per trip
+
+  // 👇 NEW: save expenses list per trip to SharedPreferences
+  // saveExpensesForTrip start
+  static Future<void> saveExpensesForTrip(String tripId, List<Expense> expenses) async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonList = expenses.map((e) => e.toJson()).toList();
+    await prefs.setString('$_kExpensesByTripKeyPrefix$tripId', jsonEncode(jsonList));
+  }
+  // saveExpensesForTrip end
+
+  // 👇 NEW: load expenses list per trip from SharedPreferences
+  // loadExpensesForTrip start
+  static Future<List<Expense>> loadExpensesForTrip(String tripId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString('$_kExpensesByTripKeyPrefix$tripId');
+    if (raw == null) return [];
+    final list = (jsonDecode(raw) as List).cast<Map<String, dynamic>>();
+    return list.map((m) => Expense.fromJson(m)).toList();
+  }
+  // loadExpensesForTrip end
+}
+// ===== LocalExpenseStore class end =====

--- a/travel_planner_app/lib/services/pending_ops_queue.dart
+++ b/travel_planner_app/lib/services/pending_ops_queue.dart
@@ -1,0 +1,40 @@
+// lib/services/pending_ops_queue.dart
+
+// ===== PendingOpsQueue class start =====
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PendingOpsQueue {
+  static const _kKey = 'pending_expense_ops_v1';
+
+  // enqueue start
+  static Future<void> enqueue(Map<String, dynamic> op) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = await _load();
+    list.add(op);
+    await prefs.setString(_kKey, jsonEncode(list));
+  }
+  // enqueue end
+
+  // drain start
+  static Future<List<Map<String, dynamic>>> drain() async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = await _load();
+    await prefs.remove(_kKey);
+    return list;
+  }
+  // drain end
+
+  // peekAll start
+  static Future<List<Map<String, dynamic>>> peekAll() => _load();
+  // peekAll end
+
+  static Future<List<Map<String, dynamic>>> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_kKey);
+    if (raw == null) return [];
+    final decoded = (jsonDecode(raw) as List).cast<Map<String, dynamic>>();
+    return decoded;
+  }
+}
+// ===== PendingOpsQueue class end =====

--- a/travel_planner_app/pubspec.yaml
+++ b/travel_planner_app/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   shared_preferences: ^2.2.2
   hive: ^2.2.3
   hive_flutter: ^1.1.0
+  connectivity_plus: ^5.0.2
   uuid: ^4.4.0
   google_sign_in: ^6.2.1
   sign_in_with_apple: ^6.1.0


### PR DESCRIPTION
## Summary
- add SharedPreferences-backed LocalExpenseStore for per-trip expense caching
- queue offline expense operations and sync when connectivity returns
- integrate optimistic expense CRUD with Hive and BudgetsSync
- wire up expense form and app shell to new API and offline sync

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3379e06dc8327921c3a05cda1ffb8