### PR TITLE
Add currency manager and settlement flow

### DIFF
--- a/travel_planner_app/lib/screens/group_balance_screen.dart
+++ b/travel_planner_app/lib/screens/group_balance_screen.dart
@@ -6,12 +6,16 @@ class GroupBalanceScreen extends StatefulWidget {
   final String tripId;
   final String currency; // show amounts in trip currency
   final ApiService api; // pass the instance if your fetch method is not static
+  final List<String> participants;
+  final List<String>? spendCurrencies;
 
   const GroupBalanceScreen({
     super.key,
     required this.tripId,
     required this.currency,
     required this.api,
+    required this.participants,
+    this.spendCurrencies,
   });
 
   @override
@@ -20,24 +24,109 @@ class GroupBalanceScreen extends StatefulWidget {
 
 class _GroupBalanceScreenState extends State<GroupBalanceScreen> {
   late Future<List<BalanceRow>> _future;
+  List<BalanceRow> _rows = [];
 
   @override
   void initState() {
     super.initState();
-    _future = widget.api.fetchGroupBalances(widget.tripId);
+    _future = _load();
+  }
+
+  Future<List<BalanceRow>> _load() async {
+    final rows = await widget.api.fetchGroupBalances(widget.tripId);
+    _rows = rows;
+    return rows;
   }
 
   Future<void> _refresh() async {
     setState(() {
-      _future = widget.api.fetchGroupBalances(widget.tripId);
+      _future = _load();
     });
     await _future;
+  }
+
+  Future<void> _openSettleDialog() async {
+    final tripId = widget.tripId;
+    final people = <String>{...widget.participants};
+    for (final r in _rows) {
+      people.add(r.from);
+      people.add(r.to);
+    }
+    final who = people.toList()..sort();
+
+    String? from = who.isNotEmpty ? who.first : null;
+    String? to   = (who.length > 1) ? who[1] : null;
+    final amount = TextEditingController();
+    String ccy = widget.currency; // default to trip currency
+    final note = TextEditingController();
+
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Settle up'),
+        content: Column(mainAxisSize: MainAxisSize.min, children: [
+          DropdownButtonFormField<String>(
+            value: from, hint: const Text('From'),
+            items: who.map((p)=>DropdownMenuItem(value:p, child: Text(p))).toList(),
+            onChanged: (v)=> from = v,
+          ),
+          const SizedBox(height: 8),
+          DropdownButtonFormField<String>(
+            value: to, hint: const Text('To'),
+            items: who.where((p)=>p!=from).map((p)=>DropdownMenuItem(value:p, child: Text(p))).toList(),
+            onChanged: (v)=> to = v,
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: amount,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            decoration: const InputDecoration(labelText: 'Amount'),
+          ),
+          const SizedBox(height: 8),
+          DropdownButtonFormField<String>(
+            value: ccy,
+            items: {widget.currency, ...?widget.spendCurrencies}.whereType<String>()
+                .map((c)=>DropdownMenuItem(value:c, child: Text(c))).toList(),
+            onChanged: (v)=> ccy = v ?? ccy,
+            decoration: const InputDecoration(labelText: 'Currency'),
+          ),
+          const SizedBox(height: 8),
+          TextField(controller: note, decoration: const InputDecoration(labelText: 'Note (optional)')),
+        ]),
+        actions: [
+          TextButton(onPressed: ()=>Navigator.pop(ctx,false), child: const Text('Cancel')),
+          FilledButton(onPressed: ()=>Navigator.pop(ctx,true), child: const Text('Record')),
+        ],
+      ),
+    );
+
+    if (ok != true || from == null || to == null) return;
+    final v = double.tryParse(amount.text.trim()) ?? 0;
+    if (v <= 0) return;
+
+    try {
+      await widget.api.createSettlement(
+        tripId: tripId, from: from!, to: to!, amount: v, currency: ccy, note: note.text.trim().isEmpty ? null : note.text.trim(),
+      );
+      await _refresh(); // reload balances/rows
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Settlement recorded')));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Failed: $e')));
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Group Balances')),
+      floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'fab-settle',
+        onPressed: _openSettleDialog,
+        icon: const Icon(Icons.handshake),
+        label: const Text('Settle up'),
+      ),
       body: RefreshIndicator(
         onRefresh: _refresh,
         child: FutureBuilder<List<BalanceRow>>(


### PR DESCRIPTION
## Summary
- allow trips to manage extra spend currencies via dashboard overflow
- enable recording settlements with a FAB on group balances screen
- polish spent currencies list formatting

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a47ed28e7c8327a6151f74ac0866c1