### PR TITLE
Sync expenses on dashboard launch

### DIFF
--- a/travel_planner_app/lib/screens/budgets_screen.dart
+++ b/travel_planner_app/lib/screens/budgets_screen.dart
@@ -37,6 +37,10 @@ class _BudgetsScreenState extends State<BudgetsScreen> with TickerProviderStateM
   Future<void> _refresh() async {
     setState(() { _loadingSpends = true; });
 
+    // reset any stale spend caches
+    _spentByTrip.clear();
+    _spentLoadedFor.clear();
+
     // 1) load known trips (server first, fallback inside the helper if you use it)
     List<Trip> trips = <Trip>[];
     try {
@@ -50,11 +54,7 @@ class _BudgetsScreenState extends State<BudgetsScreen> with TickerProviderStateM
     });
     final budgets = await _future;
 
-    // 3) clear spent caches for any removed trip
-    _spentByTrip.removeWhere((tripId, _) => !_knownTripIds.contains(tripId));
-    _spentLoadedFor.removeWhere((tripId) => !_knownTripIds.contains(tripId));
-
-    // 4) recalc spends for the remaining visible budgets
+    // 3) recalc spends for visible budgets
     await _recalcSpends(budgets);
 
     if (!mounted) return;


### PR DESCRIPTION
## Summary
- pull active trip expenses from server on dashboard startup and trip changes
- reset budgets screen spend cache before recomputing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4808cfe0c8327bb2fc8a8239a72f4