### PR TITLE
Add FX math utilities and tests

### DIFF
--- a/travel_planner_app/lib/utils/budget_math.dart
+++ b/travel_planner_app/lib/utils/budget_math.dart
@@ -1,0 +1,20 @@
+import '../models/expense.dart';
+import '../services/fx_service.dart';
+
+double spentForTripInBudgetCcy({
+  required Iterable<Expense> expenses,
+  required String budgetCurrency,
+  required Map<String, double> ratesForBaseTo, // budgetCurrency as base
+}) {
+  double sum = 0.0;
+  for (final e in expenses) {
+    final from = e.currency.isEmpty ? budgetCurrency : e.currency;
+    sum += FxService.convert(
+      amount: e.amount,
+      from: from,
+      to: budgetCurrency,
+      ratesForBaseTo: ratesForBaseTo,
+    );
+  }
+  return (sum * 100).roundToDouble() / 100.0;
+}

--- a/travel_planner_app/lib/utils/spend_math.dart
+++ b/travel_planner_app/lib/utils/spend_math.dart
@@ -1,0 +1,35 @@
+import '../models/expense.dart';
+import '../services/fx_service.dart';
+
+/// Sum amounts per *original* currency from a list of expenses.
+Map<String, double> aggregateByCurrency(Iterable<Expense> expenses) {
+  final out = <String, double>{};
+  for (final e in expenses) {
+    final c = (e.currency.isEmpty ? 'EUR' : e.currency).toUpperCase();
+    out[c] = (out[c] ?? 0) + e.amount;
+  }
+  return out;
+}
+
+/// Convert a per-currency map into a single total in [baseCurrency].
+/// Pass an FX table produced by FxService.loadRates(baseCurrency).
+double totalInBase({
+  required Map<String, double> byCurrency,
+  required String baseCurrency,
+  required Map<String, double> ratesForBaseTo,
+}) {
+  final base = baseCurrency.toUpperCase();
+  double sum = 0.0;
+  byCurrency.forEach((from, amount) {
+    sum += FxService.convert(
+      amount: amount,
+      from: from.toUpperCase(),
+      to: base,
+      ratesForBaseTo: ratesForBaseTo,
+    );
+  });
+  return _round2(sum);
+}
+
+/// Helper (banker’s rounding not needed here—just 2 dp).
+double _round2(double v) => (v * 100).roundToDouble() / 100.0;

--- a/travel_planner_app/lib/widgets/insights_card.dart
+++ b/travel_planner_app/lib/widgets/insights_card.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+class InsightsCard extends StatelessWidget {
+  const InsightsCard({
+    super.key,
+    required this.dailyBurn,
+    required this.daysLeft,
+    required this.baseCurrency,
+    required this.byCategoryBase, // already converted to base
+  });
+
+  final double dailyBurn;
+  final int daysLeft;
+  final String baseCurrency;
+  final Map<String, double> byCategoryBase;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cats = byCategoryBase.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Insights', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 12,
+              children: [
+                Text('Daily burn: ${dailyBurn.toStringAsFixed(2)} $baseCurrency'),
+                Text('Days left: $daysLeft'),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text('By category', style: theme.textTheme.bodyMedium),
+            const SizedBox(height: 8),
+            for (final e in cats)
+              Row(
+                children: [
+                  Expanded(child: Text(e.key)),
+                  Text('${e.value.toStringAsFixed(2)} $baseCurrency'),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/travel_planner_app/test/budget_math_test.dart
+++ b/travel_planner_app/test/budget_math_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_planner_app/models/expense.dart';
+import 'package:travel_planner_app/utils/budget_math.dart';
+
+Expense e(String c, double a) => Expense(
+  id: 'id', tripId: 't', title: 'x', amount: a, category: 'Food',
+  date: DateTime(2025,1,1), paidBy: 'You', sharedWith: const ['You'], currency: c,
+);
+
+void main() {
+  test('spentForTripInBudgetCcy converts each line then sums', () {
+    final ratesEUR = {
+      'EUR': 1.0, 'USD': 1 / 0.85, 'INR': 1 / 0.0098,
+    };
+    final list = [e('EUR', 10), e('USD', 10), e('INR', 1000)];
+    // 10 EUR + 10*0.85 + 1000*0.0098 = 10 + 8.5 + 9.8 = 28.3
+    final v = spentForTripInBudgetCcy(
+      expenses: list,
+      budgetCurrency: 'EUR',
+      ratesForBaseTo: ratesEUR,
+    );
+    expect(v, 28.30);
+  });
+}

--- a/travel_planner_app/test/insights_card_test.dart
+++ b/travel_planner_app/test/insights_card_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_planner_app/widgets/insights_card.dart';
+
+void main() {
+  testWidgets('InsightsCard shows burn, days, and categories', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: InsightsCard(
+            dailyBurn: 12.345,
+            daysLeft: 7,
+            baseCurrency: 'EUR',
+            byCategoryBase: {'Food': 50.0, 'Transport': 20.0},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('Daily burn:'), findsOneWidget);
+    expect(find.text('Days left: 7'), findsOneWidget);
+    expect(find.text('Food'), findsOneWidget);
+    expect(find.text('50.00 EUR'), findsOneWidget);
+    expect(find.text('Transport'), findsOneWidget);
+    expect(find.text('20.00 EUR'), findsOneWidget);
+  });
+}

--- a/travel_planner_app/test/spend_math_test.dart
+++ b/travel_planner_app/test/spend_math_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_planner_app/models/expense.dart';
+import 'package:travel_planner_app/utils/spend_math.dart';
+
+// A tiny helper to build expenses quickly.
+Expense exp(String c, double a) => Expense(
+  id: 'x',
+  tripId: 't',
+  title: 't',
+  amount: a,
+  category: 'Food',
+  date: DateTime(2025, 8, 19),
+  paidBy: 'You',
+  sharedWith: const ['You'],
+  currency: c,
+);
+
+// Fixed EUR-base table (values are units of each currency per EUR)
+final eurRates = <String, double>{
+  'EUR': 1.0,
+  'USD': 1 / 0.85,     // 1 EUR = 1.176470588 USD
+  'INR': 1 / 0.0098,   // 1 EUR = 102.0408163265 INR
+  'PLN': 1 / 0.235,    // 1 EUR = 4.2553191489 PLN
+  'JPY': 1 / 0.006,    // 1 EUR = 166.666666667 JPY
+  'AUD': 1 / 0.5577,   // 1 EUR = 1.7930787162 AUD
+};
+
+void main() {
+  group('spend_math', () {
+    test('aggregateByCurrency sums correctly', () {
+      final list = <Expense>[
+        exp('EUR', 50),
+        exp('INR', 2000),
+        exp('EUR', 10),
+        exp('usd', 3), // lower-case should be handled
+      ];
+      final agg = aggregateByCurrency(list);
+
+      expect(agg['EUR'], closeTo(60.0, 1e-9));
+      expect(agg['INR'], closeTo(2000.0, 1e-9));
+      expect(agg['USD'], closeTo(3.0, 1e-9));
+      expect(agg.keys.length, 3);
+    });
+
+    test('totalInBase converts all to base using provided table', () {
+      final by = <String, double>{'EUR': 60, 'INR': 2000, 'USD': 3};
+      final total = totalInBase(
+        byCurrency: by,
+        baseCurrency: 'EUR',
+        ratesForBaseTo: eurRates,
+      );
+      // 60*1 + 2000*0.0098 + 3*0.85 = 60 + 19.6 + 2.55 = 82.15
+      expect(total, 82.15);
+    });
+
+    test('rounding is stable at 2 decimals', () {
+      final by = <String, double>{'JPY': 1}; // 1 * 0.006 = 0.006 → 0.01
+      final total = totalInBase(
+        byCurrency: by,
+        baseCurrency: 'EUR',
+        ratesForBaseTo: eurRates,
+      );
+      expect(total, 0.01);
+    });
+
+    test('handles empty set', () {
+      final t = totalInBase(
+        byCurrency: const {},
+        baseCurrency: 'EUR',
+        ratesForBaseTo: eurRates,
+      );
+      expect(t, 0.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add spend and budget FX math helpers
- introduce InsightsCard widget
- cover math and widget with unit tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b1365f088327a4b84390aa62bc24