### PR TITLE
Show budget decimals in budgets screen

### DIFF
--- a/travel_planner_app/lib/screens/budgets_screen.dart
+++ b/travel_planner_app/lib/screens/budgets_screen.dart
@@ -478,7 +478,7 @@ class _BudgetsScreenState extends State<BudgetsScreen> with TickerProviderStateM
 
   // --- money formatting + spent cache ---
 // money formatter (very simple; replace with intl if you want)
-  String _money(String ccy, num v) => '$ccy ${v.toStringAsFixed(0)}';
+  String _money(String ccy, num v, {int dp = 2}) => '$ccy ${v.toStringAsFixed(dp)}';
 
 // // Cache: tripId -> spent amount
 //   final Map<String, double> _spentByTrip = <String, double>{};
@@ -654,9 +654,9 @@ class _BudgetsScreenState extends State<BudgetsScreen> with TickerProviderStateM
                           return Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              Text('Total: ${_money(m.currency, m.amount)}'),
-                              Text('Spent: ${_money(m.currency, spent)}'),
-                              Text('Remaining: ${_money(m.currency, remaining)}'),
+                              Text('Total: ${_money(m.currency, m.amount, dp: 2)}'),
+                              Text('Spent: ${_money(m.currency, spent, dp: 2)}'),
+                              Text('Remaining: ${_money(m.currency, remaining, dp: 2)}'),
                             ],
                           );
                         },
@@ -701,9 +701,9 @@ class _BudgetsScreenState extends State<BudgetsScreen> with TickerProviderStateM
 
                           final lines = <Widget>[
                             // your existing totals
-                            Text('Total: ${_money(t.currency, t.amount)}'),
-                            Text('Spent: ${_money(t.currency, spent)}'),
-                            Text('Remaining: ${_money(t.currency, remaining)}'),
+                            Text('Total: ${_money(t.currency, t.amount, dp: 2)}'),
+                            Text('Spent: ${_money(t.currency, spent, dp: 2)}'),
+                            Text('Remaining: ${_money(t.currency, remaining, dp: 2)}'),
                             const SizedBox(height: 4),
                           ];
 

--- a/travel_planner_app/lib/screens/dashboard_screen.dart
+++ b/travel_planner_app/lib/screens/dashboard_screen.dart
@@ -258,6 +258,10 @@ class _DashboardScreenState extends State<DashboardScreen> with WidgetsBindingOb
     }
 
     // 4) Daily burn / days left
+    // daysSoFar = max(1, today - startDate + 1)
+    // dailyBurn = spentInTripCurrency / daysSoFar
+    // remaining = max(0, budget - spentInTripCurrency)
+    // days left = ceil(remaining / dailyBurn) (burn == 0 -> 0)
     final daysSoFar = (DateTime.now().difference(t.startDate).inDays + 1).clamp(1, 36500);
     final burn = totalBase / daysSoFar;
     int? daysLeft;


### PR DESCRIPTION
## Summary
- Allow specifying decimal places in `_money` helper and default to two
- Display totals, spent, and remaining amounts with two decimals on budget cards
- Clarify days-left calculation with inline comments

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `snap install flutter --classic` *(fails: cannot communicate with server)*

------
https://chatgpt.com/codex/tasks/task_e_68a57f049a7c8327b05c03ec370d9b8f