### PR TITLE
feat: add monthly category envelopes and overview

### DIFF
--- a/travel_planner_app/lib/models/monthly_category.dart
+++ b/travel_planner_app/lib/models/monthly_category.dart
@@ -1,0 +1,83 @@
+class MonthlySubcategory {
+  final String id;
+  final String name;
+  final double planned; // planned amount for the month
+  MonthlySubcategory({
+    required this.id,
+    required this.name,
+    this.planned = 0,
+  });
+
+  MonthlySubcategory copyWith({String? id, String? name, double? planned}) =>
+      MonthlySubcategory(
+        id: id ?? this.id,
+        name: name ?? this.name,
+        planned: planned ?? this.planned,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'planned': planned,
+      };
+  factory MonthlySubcategory.fromJson(Map<String, dynamic> j) =>
+      MonthlySubcategory(
+        id: j['id'] as String,
+        name: j['name'] as String,
+        planned: (j['planned'] as num?)?.toDouble() ?? 0,
+      );
+}
+
+enum MonthlyKind { income, expense }
+
+class MonthlyCategory {
+  final String id;
+  final MonthlyKind kind;
+  final String name; // e.g. “Food”, “Salary”
+  final String currency; // envelope currency (usually your monthly base)
+  final List<MonthlySubcategory> subs;
+
+  MonthlyCategory({
+    required this.id,
+    required this.kind,
+    required this.name,
+    required this.currency,
+    this.subs = const [],
+  });
+
+  MonthlyCategory copyWith({
+    String? id,
+    MonthlyKind? kind,
+    String? name,
+    String? currency,
+    List<MonthlySubcategory>? subs,
+  }) =>
+      MonthlyCategory(
+        id: id ?? this.id,
+        kind: kind ?? this.kind,
+        name: name ?? this.name,
+        currency: currency ?? this.currency,
+        subs: subs ?? this.subs,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'kind': kind.name,
+        'name': name,
+        'currency': currency,
+        'subs': subs.map((s) => s.toJson()).toList(),
+      };
+
+  factory MonthlyCategory.fromJson(Map<String, dynamic> j) => MonthlyCategory(
+        id: j['id'] as String,
+        kind: (j['kind'] as String) == 'income'
+            ? MonthlyKind.income
+            : MonthlyKind.expense,
+        name: j['name'] as String,
+        currency: (j['currency'] as String?) ?? 'EUR',
+        subs: ((j['subs'] as List?) ?? const [])
+            .map((e) => MonthlySubcategory.fromJson(
+                Map<String, dynamic>.from(e as Map)))
+            .toList(),
+      );
+}

--- a/travel_planner_app/lib/screens/monthly_budget_screen.dart
+++ b/travel_planner_app/lib/screens/monthly_budget_screen.dart
@@ -1,330 +1,374 @@
 import 'package:flutter/material.dart';
-import '../models/budget.dart';
 import '../services/api_service.dart';
+import '../models/monthly_category.dart';
+import '../services/monthly_store.dart';
+import '../services/monthly_calc.dart';
 
 class MonthlyBudgetScreen extends StatefulWidget {
   final ApiService api;
   const MonthlyBudgetScreen({super.key, required this.api});
-
   @override
   State<MonthlyBudgetScreen> createState() => _MonthlyBudgetScreenState();
 }
 
-class _MonthlyBudgetScreenState extends State<MonthlyBudgetScreen> {
+class _MonthlyBudgetScreenState extends State<MonthlyBudgetScreen>
+    with TickerProviderStateMixin {
   DateTime _month = DateTime(DateTime.now().year, DateTime.now().month);
-  late Future<MonthlyBudgetSummary> _summaryFut;
-  late Future<List<Budget>> _budgetsFut;
+  late Future<List<MonthlyCategory>> _envFut;
+  String _ccy = 'EUR'; // monthly base currency (can add a setting later)
+  late final TabController _tabs;
 
   @override
   void initState() {
     super.initState();
+    _tabs = TabController(length: 2, vsync: this);
     _load();
   }
 
   void _load() {
-    _summaryFut = widget.api.fetchMonthlySummary(_month);
-    _budgetsFut = widget.api.fetchMonthlyBudgets(_month);
+    _envFut = MonthlyStore.load(_month);
   }
 
   Future<void> _pickMonth() async {
-    // Simple month switcher (minus/plus). You can swap for a month picker later.
+    final now = DateTime.now();
+    final months = List.generate(15, (i) {
+      final d = DateTime(now.year, now.month - 7 + i);
+      return DateTime(d.year, d.month);
+    });
     final picked = await showModalBottomSheet<DateTime>(
       context: context,
       showDragHandle: true,
-      builder: (ctx) {
-        final months = List.generate(13, (i) {
-          final d = DateTime(_month.year, _month.month - 6 + i);
-          return DateTime(d.year, d.month);
-        });
+      builder: (ctx) => ListView(
+        children: months
+            .map((m) => ListTile(
+                  title: Text('${_m(m.month)} ${m.year}'),
+                  onTap: () => Navigator.pop(ctx, m),
+                ))
+            .toList(),
+      ),
+    );
+    if (picked != null) setState(() {
+      _month = picked;
+      _load();
+    });
+  }
+
+  // Add/Edit dialogs
+  Future<void> _addCategory(MonthlyKind kind) async {
+    final name = TextEditingController();
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('New ${kind == MonthlyKind.income ? "Income" : "Expense"} Category'),
+        content: TextField(
+            controller: name, decoration: const InputDecoration(labelText: 'Name')),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Create')),
+        ],
+      ),
+    );
+    if (ok != true || name.text.trim().isEmpty) return;
+    final list = await _envFut;
+    final next = [
+      ...list,
+      MonthlyCategory(
+        id: 'cat_${DateTime.now().millisecondsSinceEpoch}',
+        kind: kind,
+        name: name.text.trim(),
+        currency: _ccy,
+        subs: const [],
+      ),
+    ];
+    await MonthlyStore.save(_month, next);
+    if (mounted) setState(_load);
+  }
+
+  Future<void> _addSub(MonthlyCategory cat) async {
+    final name = TextEditingController();
+    final planned = TextEditingController(text: '0');
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('Add subcategory to ${cat.name}'),
+        content: Column(mainAxisSize: MainAxisSize.min, children: [
+          TextField(
+              controller: name, decoration: const InputDecoration(labelText: 'Name')),
+          const SizedBox(height: 8),
+          TextField(
+              controller: planned,
+              decoration: const InputDecoration(labelText: 'Planned'),
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true)),
+        ]),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Add')),
+        ],
+      ),
+    );
+    if (ok != true || name.text.trim().isEmpty) return;
+    final list = await _envFut;
+    final idx = list.indexWhere((c) => c.id == cat.id);
+    if (idx < 0) return;
+    final sub = MonthlySubcategory(
+      id: 'sub_${DateTime.now().millisecondsSinceEpoch}',
+      name: name.text.trim(),
+      planned: double.tryParse(planned.text.trim()) ?? 0,
+    );
+    final updated = list[idx].copyWith(subs: [...list[idx].subs, sub]);
+    final next = [...list]..[idx] = updated;
+    await MonthlyStore.save(_month, next);
+    if (mounted) setState(_load);
+  }
+
+  Future<void> _editSub(MonthlyCategory cat, MonthlySubcategory sub) async {
+    final name = TextEditingController(text: sub.name);
+    final planned = TextEditingController(text: sub.planned.toString());
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('Edit ${cat.name} ▸ ${sub.name}'),
+        content: Column(mainAxisSize: MainAxisSize.min, children: [
+          TextField(
+              controller: name, decoration: const InputDecoration(labelText: 'Name')),
+          const SizedBox(height: 8),
+          TextField(
+              controller: planned,
+              decoration: const InputDecoration(labelText: 'Planned'),
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true)),
+        ]),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Save')),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    final list = await _envFut;
+    final ci = list.indexWhere((c) => c.id == cat.id);
+    if (ci < 0) return;
+    final si = list[ci].subs.indexWhere((s) => s.id == sub.id);
+    if (si < 0) return;
+    final updSub = sub.copyWith(
+      name: name.text.trim().isEmpty ? sub.name : name.text.trim(),
+      planned: double.tryParse(planned.text.trim()) ?? sub.planned,
+    );
+    final nextSubs = [...list[ci].subs]..[si] = updSub;
+    final updCat = list[ci].copyWith(subs: nextSubs);
+    final next = [...list]..[ci] = updCat;
+    await MonthlyStore.save(_month, next);
+    if (mounted) setState(_load);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: InkWell(
+          onTap: _pickMonth,
+          child: Row(mainAxisSize: MainAxisSize.min, children: [
+            Text('${_m(_month.month)} ${_month.year}'),
+            const SizedBox(width: 6),
+            const Icon(Icons.expand_more, size: 18),
+          ]),
+        ),
+        bottom: TabBar(
+          controller: _tabs,
+          tabs: const [Tab(text: 'Overview'), Tab(text: 'Categories')],
+        ),
+      ),
+      floatingActionButton: _tabs.index == 1
+          ? Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FloatingActionButton.extended(
+                  heroTag: 'fab-income',
+                  onPressed: () => _addCategory(MonthlyKind.income),
+                  icon: const Icon(Icons.add),
+                  label: const Text('Add Income'),
+                ),
+                const SizedBox(height: 10),
+                FloatingActionButton.extended(
+                  heroTag: 'fab-expense',
+                  onPressed: () => _addCategory(MonthlyKind.expense),
+                  icon: const Icon(Icons.add),
+                  label: const Text('Add Expense'),
+                ),
+              ],
+            )
+          : null,
+      body: FutureBuilder<List<MonthlyCategory>>(
+        future: _envFut,
+        builder: (context, snap) {
+          if (!snap.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final envs = snap.data!;
+          return TabBarView(
+            controller: _tabs,
+            children: [
+              _overview(envs),
+              _categories(envs),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _overview(List<MonthlyCategory> envs) {
+    return FutureBuilder<MonthlyTotals>(
+      future: computeTotals(
+          month: _month,
+          envelopes: envs,
+          monthlyCurrency: _ccy,
+          api: widget.api),
+      builder: (context, s) {
+        if (!s.hasData) return const Center(child: CircularProgressIndicator());
+        final t = s.data!;
+        final left = (t.planned - t.spent);
+        final pctSpent = (t.planned <= 0) ? 0 : (t.spent / t.planned).clamp(0, 1.0);
         return ListView(
-          children: months
-              .map((m) => ListTile(
-                    title: Text('${_monthName(m.month)} ${m.year}'),
-                    onTap: () => Navigator.pop(ctx, m),
-                  ))
-              .toList(),
+          padding: const EdgeInsets.all(16),
+          children: [
+            _OverviewCard(
+              leftOver: left,
+              pctSpent: pctSpent,
+              totalBudgeted: t.planned,
+              remaining: left < 0 ? 0 : left,
+              currency: t.currency,
+            ),
+            const SizedBox(height: 12),
+            Text('Quick month picker',
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 6),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: List.generate(6, (i) {
+                final d = DateTime(_month.year, _month.month - 2 + i);
+                return ActionChip(
+                  label: Text('${_m(d.month)} ${d.year}'),
+                  onPressed: () => setState(() {
+                    _month = DateTime(d.year, d.month);
+                    _load();
+                  }),
+                );
+              }),
+            ),
+          ],
         );
       },
     );
-    if (picked != null) {
-      setState(() {
-        _month = picked;
-        _load();
-      });
-    }
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(icon: const Icon(Icons.menu), onPressed: () {}),
-        title: InkWell(
-          onTap: _pickMonth,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text('${_monthName(_month.month)} ${_month.year}'),
-              const SizedBox(width: 6),
-              const Icon(Icons.expand_more, size: 18),
-            ],
-          ),
-        ),
-        centerTitle: true,
-        actions: [
-          IconButton(icon: const Icon(Icons.search), onPressed: () {}),
-          IconButton(icon: const Icon(Icons.person_add_alt), onPressed: () {}),
-        ],
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          /* open add budget or add transaction */
-        },
-        child: const Icon(Icons.add),
-      ),
-      body: RefreshIndicator(
-        onRefresh: () async {
-          setState(_load);
-          await Future.wait([_summaryFut, _budgetsFut]).catchError((_) {});
-        },
-        child: FutureBuilder(
-          future: Future.wait([_summaryFut, _budgetsFut]),
-          builder: (context, snap) {
-            if (snap.connectionState == ConnectionState.waiting) {
-              return const Center(child: CircularProgressIndicator());
-            }
-            if (snap.hasError) {
-              return ListView(
-                children: const [
-                  SizedBox(height: 100),
-                  Center(child: Text('Could not load budgets')),
-                ],
-              );
-            }
-            final summary = (snap.data as List)[0] as MonthlyBudgetSummary;
-            final budgets = (snap.data as List)[1] as List<Budget>;
-
-            return ListView(
-              padding: const EdgeInsets.only(bottom: 100),
-              children: [
-                _Header(summary: summary),
-                const SizedBox(height: 12),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: _LegendRow(summary: summary),
-                ),
-                const SizedBox(height: 12),
-                const _SectionTitle('Budgets'),
-                const SizedBox(height: 8),
-                ...budgets.map((b) => _BudgetRow(budget: b)).toList(),
-                const SizedBox(height: 16),
-              ],
-            );
-          },
-        ),
-      ),
-    );
-  }
-
-  String _monthName(int m) {
-    const names = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec'
-    ];
-    return names[(m - 1) % 12];
-  }
-}
-
-class _Header extends StatelessWidget {
-  final MonthlyBudgetSummary summary;
-  const _Header({required this.summary});
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final pct = summary.pctSpent;
-    return Container(
-      margin: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: cs.outlineVariant),
-      ),
-      child: Column(
-        children: [
-          Row(
-            children: [
-              _Ring(value: pct),
-              const SizedBox(width: 16),
-              Expanded(
-                child: DefaultTextStyle(
-                  style: Theme.of(context).textTheme.bodyMedium!,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text('Left Over',
-                          style: Theme.of(context).textTheme.labelLarge),
-                      const SizedBox(height: 4),
-                      Text(
-                        '${summary.remaining.toStringAsFixed(2)} ${summary.currency}',
-                        style: Theme.of(context)
-                            .textTheme
-                            .headlineSmall!
-                            .copyWith(fontWeight: FontWeight.w800),
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                          '${(pct * 100).toStringAsFixed(2)}% of income spent',
-                          style: Theme.of(context)
-                              .textTheme
-                              .labelMedium!
-                              .copyWith(color: cs.secondary)),
-                    ],
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          const Divider(height: 1),
-          const SizedBox(height: 12),
-          _StatRow(
-            leftLabel: 'Total Budgeted',
-            leftValue:
-                '${summary.totalBudgeted.toStringAsFixed(2)} ${summary.currency}',
-            midLabel: 'Provisional Balance',
-            midValue: '0.00 ${summary.currency}',
-            rightLabel: 'Remaining to Spend',
-            rightValue:
-                '${summary.remaining.toStringAsFixed(2)} ${summary.currency}',
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _LegendRow extends StatelessWidget {
-  final MonthlyBudgetSummary summary;
-  const _LegendRow({required this.summary});
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return Row(
+  Widget _categories(List<MonthlyCategory> envs) {
+    final income = envs.where((c) => c.kind == MonthlyKind.income).toList();
+    final expense = envs.where((c) => c.kind == MonthlyKind.expense).toList();
+    return ListView(
+      padding: const EdgeInsets.only(bottom: 120),
       children: [
-        _LegendChip(
-            icon: Icons.account_balance_wallet_outlined,
-            label: 'Budget Spent',
-            color: cs.primary),
-        const Spacer(),
-        Text('${(summary.pctSpent * 100).toStringAsFixed(2)}%',
-            style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: 8),
+        _section('Income', income, allowAddSub: true),
+        const SizedBox(height: 12),
+        _section('Expenses', expense, allowAddSub: true),
       ],
     );
   }
-}
 
-class _Ring extends StatelessWidget {
-  final double value; // 0..1
-  const _Ring({required this.value});
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return SizedBox(
-      width: 110,
-      height: 110,
-      child: Stack(
-        alignment: Alignment.center,
-        children: [
-          CircularProgressIndicator(
-            value: 1,
-            strokeWidth: 10,
-            color: cs.surfaceVariant,
-          ),
-          CircularProgressIndicator(
-            value: value,
-            strokeWidth: 10,
-            color: cs.primary,
-          ),
-          Text('${(value * 100).round()}%',
-              style: Theme.of(context)
-                  .textTheme
-                  .titleMedium!
-                  .copyWith(fontWeight: FontWeight.w800)),
-        ],
-      ),
+  Widget _section(String title, List<MonthlyCategory> cats,
+      {required bool allowAddSub}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(4, 8, 4, 6),
+          child: Text(title, style: Theme.of(context).textTheme.titleMedium),
+        ),
+        ...cats.map((c) {
+          final planned = c.subs.fold<double>(0, (p, s) => p + s.planned);
+          return Card(
+            child: ExpansionTile(
+              title: Text('${c.name} • Planned ${planned.toStringAsFixed(2)} ${c.currency}'),
+              children: [
+                for (final s in c.subs)
+                  ListTile(
+                    title: Text(s.name),
+                    subtitle: const LinearProgressIndicator(
+                      value: 0, // (wire a per-sub spent if you want later)
+                      minHeight: 8,
+                    ),
+                    trailing:
+                        Text('${s.planned.toStringAsFixed(2)} ${c.currency}'),
+                    onTap: () => _editSub(c, s),
+                  ),
+                if (allowAddSub)
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton.icon(
+                      onPressed: () => _addSub(c),
+                      icon: const Icon(Icons.add),
+                      label: const Text('Add subcategory'),
+                    ),
+                  ),
+              ],
+            ),
+          );
+        }),
+      ]),
     );
   }
+
+  String _m(int m) =>
+      const [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec'
+      ][m - 1];
 }
 
-class _StatRow extends StatelessWidget {
-  final String leftLabel, leftValue, midLabel, midValue, rightLabel, rightValue;
-  const _StatRow({
-    required this.leftLabel,
-    required this.leftValue,
-    required this.midLabel,
-    required this.midValue,
-    required this.rightLabel,
-    required this.rightValue,
+class _OverviewCard extends StatelessWidget {
+  final double leftOver;
+  final double pctSpent; // 0..1
+  final double totalBudgeted;
+  final double remaining;
+  final String currency;
+  const _OverviewCard({
+    required this.leftOver,
+    required this.pctSpent,
+    required this.totalBudgeted,
+    required this.remaining,
+    required this.currency,
   });
 
-  Widget _cell(BuildContext c, String label, String value) {
-    final t = Theme.of(c).textTheme;
-    return Expanded(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(label, style: t.labelSmall),
-          const SizedBox(height: 2),
-          Text(value, style: t.titleMedium!.copyWith(fontWeight: FontWeight.w700)),
-        ],
-      ),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(children: [
-      _cell(context, leftLabel, leftValue),
-      _cell(context, midLabel, midValue),
-      _cell(context, rightLabel, rightValue),
-    ]);
-  }
-}
-
-class _BudgetRow extends StatelessWidget {
-  final Budget budget;
-  const _BudgetRow({required this.budget});
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final colors = [
-      cs.primary,
-      cs.tertiary,
-      cs.secondary,
-      cs.error,
-      cs.primaryContainer,
-      cs.secondaryContainer,
-    ];
-    final color = colors[budget.colorIndex % colors.length];
     return Container(
-      margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-      padding: const EdgeInsets.all(14),
+      padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: Theme.of(context).cardColor,
         borderRadius: BorderRadius.circular(16),
@@ -333,61 +377,33 @@ class _BudgetRow extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              _Circle(
-                  color: color,
-                  label: budget.name.isNotEmpty
-                      ? budget.name[0].toUpperCase()
-                      : '?'),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(budget.name,
-                        style: const TextStyle(fontWeight: FontWeight.w800)),
-                    const SizedBox(height: 2),
-                    Text(
-                      'Spending  ${budget.spent.toStringAsFixed(2)} ${budget.currency}',
-                      style: Theme.of(context).textTheme.bodySmall,
-                    ),
-                  ],
-                ),
-              ),
-              IconButton(
-                icon: const Icon(Icons.add_circle_outline),
-                onPressed: () {
-                  /* Quick add to this budget */
-                },
-                tooltip: 'Add',
-              ),
-            ],
-          ),
-          const SizedBox(height: 10),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(8),
-            child: LinearProgressIndicator(
-              value: budget.pct,
-              minHeight: 10,
-              color: color,
-              backgroundColor: cs.surfaceVariant,
-            ),
-          ),
+          Text('Left Over', style: Theme.of(context).textTheme.labelLarge),
           const SizedBox(height: 6),
+          Text(
+            '${leftOver.toStringAsFixed(2)} $currency',
+            style: Theme.of(context)
+                .textTheme
+                .headlineSmall!
+                .copyWith(fontWeight: FontWeight.w800),
+          ),
+          const SizedBox(height: 12),
+          LinearProgressIndicator(
+            value: pctSpent,
+            minHeight: 10,
+          ),
+          const SizedBox(height: 8),
           Row(
             children: [
               Expanded(
-                  child: Text(
-                'Actual Budgeted  ${budget.planned.toStringAsFixed(2)} ${budget.currency}',
-                style: Theme.of(context).textTheme.labelSmall,
-              )),
-              Expanded(
-                  child: Text(
-                'Remaining to spend  ${(budget.planned - budget.spent).clamp(0, double.infinity).toStringAsFixed(2)} ${budget.currency}',
-                textAlign: TextAlign.end,
-                style: Theme.of(context).textTheme.labelSmall,
-              )),
+                  child: Text('Budget Spent ${(pctSpent * 100).toStringAsFixed(1)}%')),
+              Text('Total ${totalBudgeted.toStringAsFixed(2)} $currency'),
+            ],
+          ),
+          const Divider(height: 20),
+          Row(
+            children: [
+              Expanded(child: Text('Remaining to spend')),
+              Text('${remaining.toStringAsFixed(2)} $currency'),
             ],
           ),
         ],
@@ -395,66 +411,3 @@ class _BudgetRow extends StatelessWidget {
     );
   }
 }
-
-class _Circle extends StatelessWidget {
-  final Color color;
-  final String label;
-  const _Circle({required this.color, required this.label});
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return CircleAvatar(
-      radius: 18,
-      backgroundColor: color.withOpacity(.15),
-      child: Text(label,
-          style:
-              TextStyle(color: color, fontWeight: FontWeight.w900)),
-    );
-  }
-}
-
-class _SectionTitle extends StatelessWidget {
-  final String text;
-  const _SectionTitle(this.text, {super.key});
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 6),
-      child: Text(text,
-          style: Theme.of(context)
-              .textTheme
-              .titleMedium!
-              .copyWith(fontWeight: FontWeight.w800)),
-    );
-  }
-}
-
-class _LegendChip extends StatelessWidget {
-  final IconData icon;
-  final String label;
-  final Color color;
-  const _LegendChip(
-      {required this.icon, required this.label, required this.color});
-
-  @override
-  Widget build(BuildContext context) {
-    final t = Theme.of(context).textTheme;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: color.withOpacity(.15),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 16, color: color),
-          const SizedBox(width: 4),
-          Text(label,
-              style: t.labelSmall!.copyWith(fontWeight: FontWeight.w500, color: color)),
-        ],
-      ),
-    );
-  }
-}
-

--- a/travel_planner_app/lib/services/category_matcher.dart
+++ b/travel_planner_app/lib/services/category_matcher.dart
@@ -1,0 +1,23 @@
+import '../models/monthly_category.dart';
+
+/// Returns (catId, subId) if a human string matches any subcategory name.
+({String catId, String subId})? matchByName(
+  String expenseCategory,
+  List<MonthlyCategory> envelopes,
+) {
+  final q = expenseCategory.trim().toLowerCase();
+  for (final c in envelopes) {
+    for (final s in c.subs) {
+      if (s.name.trim().toLowerCase() == q) {
+        return (catId: c.id, subId: s.id);
+      }
+    }
+  }
+  // fallback: match main category
+  for (final c in envelopes) {
+    if (c.name.trim().toLowerCase() == q && c.subs.isNotEmpty) {
+      return (catId: c.id, subId: c.subs.first.id);
+    }
+  }
+  return null;
+}

--- a/travel_planner_app/lib/services/monthly_calc.dart
+++ b/travel_planner_app/lib/services/monthly_calc.dart
@@ -1,0 +1,74 @@
+import 'package:hive/hive.dart';
+import '../models/expense.dart';
+import '../models/monthly_category.dart';
+import '../services/api_service.dart';
+
+class MonthlyTotals {
+  final double planned;
+  final double spent;
+  final String currency;
+  MonthlyTotals({required this.planned, required this.spent, required this.currency});
+  double get remaining => (planned - spent);
+  double get pct => planned <= 0 ? 0 : (spent / planned).clamp(0, 1);
+}
+
+/// Sums planned (from envelopes) and spent (from local expenses) for the month.
+/// NOTE: Spent is summed by matching expense.category to subcategory name.
+///       Cross-currency conversion can be added with ApiService.convert(...).
+Future<MonthlyTotals> computeTotals({
+  required DateTime month,
+  required List<MonthlyCategory> envelopes,
+  required String monthlyCurrency,
+  required ApiService api,
+}) async {
+  final box = Hive.box<Expense>('expensesBox');
+  final start = DateTime(month.year, month.month, 1);
+  final end = DateTime(month.year, month.month + 1, 1);
+
+  // Planned = sum of all sub planned in monthlyCurrency
+  final planned = envelopes.fold<double>(0, (p, c) =>
+      p + c.subs.fold<double>(0, (pp, s) => pp + s.planned));
+
+  // Spent = sum of expenses in the month, mapped to envelopes by name
+  double spent = 0;
+  for (final e in box.values) {
+    final d = e.date;
+    if (d.isBefore(start) || !d.isBefore(end)) continue;
+
+    // match by sub name first (exact), then by category name → put into first sub
+    final lower = e.category.trim().toLowerCase();
+    MonthlyCategory? cat;
+    MonthlySubcategory? sub;
+    for (final c in envelopes) {
+      for (final s in c.subs) {
+        if (s.name.trim().toLowerCase() == lower) {
+          cat = c;
+          sub = s;
+          break;
+        }
+      }
+      if (cat != null) break;
+    }
+    cat ??= envelopes.firstWhere(
+      (c) => c.name.trim().toLowerCase() == lower,
+      orElse: () => envelopes.isEmpty ? null as MonthlyCategory : envelopes.first,
+    );
+    if (cat == null) continue;
+
+    // currency conversion (TODO: use api.convert if different)
+    final from = e.currency.toUpperCase();
+    final to = monthlyCurrency.toUpperCase();
+    final value = (from == to)
+        ? e.amount
+        : await api.convert(amount: e.amount, from: from, to: to);
+
+    // Income reduces “spent” (spent can be negative → more left over)
+    if (cat.kind == MonthlyKind.income) {
+      spent -= value;
+    } else {
+      spent += value;
+    }
+  }
+
+  return MonthlyTotals(planned: planned, spent: spent, currency: monthlyCurrency);
+}

--- a/travel_planner_app/lib/services/monthly_store.dart
+++ b/travel_planner_app/lib/services/monthly_store.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/monthly_category.dart';
+
+class MonthlyStore {
+  static String _key(DateTime month) =>
+      'monthly_envelopes_${month.year}_${month.month.toString().padLeft(2, '0')}';
+
+  /// Load envelopes (Income + Expense) for a month.
+  static Future<List<MonthlyCategory>> load(DateTime month) async {
+    final p = await SharedPreferences.getInstance();
+    final s = p.getString(_key(month));
+    if (s == null || s.isEmpty) return _seed(month);
+    try {
+      final raw = (jsonDecode(s) as List).cast<Map<String, dynamic>>();
+      return raw.map(MonthlyCategory.fromJson).toList();
+    } catch (_) {
+      return _seed(month);
+    }
+  }
+
+  /// Save the full set for the month.
+  static Future<void> save(DateTime month, List<MonthlyCategory> list) async {
+    final p = await SharedPreferences.getInstance();
+    await p.setString(
+      _key(month),
+      jsonEncode(list.map((e) => e.toJson()).toList()),
+    );
+  }
+
+  /// First‑time defaults (you can tweak freely)
+  static List<MonthlyCategory> _seed(DateTime month) {
+    return [
+      MonthlyCategory(
+        id: 'cat_income_salary',
+        kind: MonthlyKind.income,
+        name: 'Salary',
+        currency: 'EUR',
+        subs: [MonthlySubcategory(id: 'sub_base', name: 'Base', planned: 0)],
+      ),
+      MonthlyCategory(
+        id: 'cat_exp_food',
+        kind: MonthlyKind.expense,
+        name: 'Food',
+        currency: 'EUR',
+        subs: [
+          MonthlySubcategory(
+              id: 'sub_groceries', name: 'Groceries', planned: 200),
+          MonthlySubcategory(
+              id: 'sub_eatingout', name: 'Eating out', planned: 150),
+        ],
+      ),
+      MonthlyCategory(
+        id: 'cat_exp_transport',
+        kind: MonthlyKind.expense,
+        name: 'Transport',
+        currency: 'EUR',
+        subs: [
+          MonthlySubcategory(
+              id: 'sub_public', name: 'Public', planned: 50),
+          MonthlySubcategory(
+              id: 'sub_ride', name: 'Ride-hailing', planned: 50),
+        ],
+      ),
+    ];
+  }
+}


### PR DESCRIPTION
## Summary
- add model and store for monthly envelope categories and subcategories
- compute monthly totals from local expenses and envelopes
- redesign monthly budget screen with overview and category editing UI

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bce57d1c8327abfbe3c37435540c