### PR TITLE
Add client-side Monthly overview with envelopes

### DIFF
--- a/travel_planner_app/lib/models/monthly.dart
+++ b/travel_planner_app/lib/models/monthly.dart
@@ -1,0 +1,46 @@
+// monthly.dart start
+// 👇 NEW: Monthly overview + envelopes data models
+class MonthlyBudgetSummary {
+  final String currency;        // e.g., 'EUR'
+  final double totalBudgeted;   // sum of all monthly budgets (in their own ccy converted to currency)
+  final double totalSpent;      // sum of linked trip spends converted to currency
+  final double remaining;       // totalBudgeted - totalSpent
+  final double pctSpent;        // clamp 0..1
+
+  const MonthlyBudgetSummary({
+    required this.currency,
+    required this.totalBudgeted,
+    required this.totalSpent,
+    required this.remaining,
+    required this.pctSpent,
+  });
+}
+
+class MonthlyEnvelope {
+  final String id;              // stable id (can reuse budget id)
+  final String name;            // e.g., 'Food' or 'Income: Salary'
+  final String currency;        // envelope currency (usually same as monthly currency)
+  final double planned;         // budgeted amount
+  final double spent;           // computed spent
+  final int colorIndex;         // for row color variation
+  final List<MonthlyEnvelope> children; // optional sub-categories
+
+  const MonthlyEnvelope({
+    required this.id,
+    required this.name,
+    required this.currency,
+    required this.planned,
+    required this.spent,
+    this.colorIndex = 0,
+    this.children = const <MonthlyEnvelope>[],
+  });
+
+  double get pct {
+    if (planned <= 0) return 0;
+    final p = spent / planned;
+    if (p < 0) return 0;
+    if (p > 1.0) return 1.0;
+    return p;
+  }
+}
+// monthly.dart end

--- a/travel_planner_app/lib/screens/app_shell.dart
+++ b/travel_planner_app/lib/screens/app_shell.dart
@@ -9,6 +9,7 @@ import 'budgets_screen.dart';
 import 'dashboard_screen.dart';
 import 'expenses_screen.dart';
 import 'trip_selection_screen.dart';
+import 'monthly_budget_screen.dart'; // 👈 NEW
 // app_shell imports patch end
 
 
@@ -86,6 +87,7 @@ class _AppShellState extends State<AppShell> {
       ),
       ExpensesScreen(api: widget.api),
       BudgetsScreen(api: widget.api),
+      MonthlyBudgetScreen(api: widget.api), // 👈 NEW: fourth tab
     ];
 
     return Scaffold(
@@ -97,6 +99,7 @@ class _AppShellState extends State<AppShell> {
           NavigationDestination(icon: Icon(Icons.dashboard_outlined), label: 'Home'),
           NavigationDestination(icon: Icon(Icons.receipt_long_outlined), label: 'Expenses'),
           NavigationDestination(icon: Icon(Icons.savings_outlined), label: 'Budgets'),
+          NavigationDestination(icon: Icon(Icons.pie_chart_outline), label: 'Monthly'), // 👈 NEW
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- add MonthlyBudgetSummary and MonthlyEnvelope models
- compute monthly summary and envelopes in ApiService
- create MonthlyBudgetScreen and expose via AppShell

## Testing
- `flutter format lib/models/monthly.dart lib/screens/monthly_budget_screen.dart lib/services/api_service.dart lib/screens/app_shell.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a5c19314448327a07469ee33e0aeac