### PR TITLE
Add monthly budget envelopes and overview

### DIFF
--- a/travel_planner_app/lib/models/envelope.dart
+++ b/travel_planner_app/lib/models/envelope.dart
@@ -1,0 +1,65 @@
+enum EnvelopeType { income, expense }
+
+class EnvelopeDef {
+  final String id;          // unique id (string)
+  final String name;        // e.g., "Groceries" / "Salary"
+  final EnvelopeType type;  // income or expense
+  final double planned;     // user-planned amount (in monthly currency)
+  final String currency;    // ISO (monthly currency; we normalize to Home)
+  final String? parentId;   // for subcategories
+
+  EnvelopeDef({
+    required this.id,
+    required this.name,
+    required this.type,
+    required this.planned,
+    required this.currency,
+    this.parentId,
+  });
+
+  EnvelopeDef copyWith({
+    String? id,
+    String? name,
+    EnvelopeType? type,
+    double? planned,
+    String? currency,
+    String? parentId,
+  }) {
+    return EnvelopeDef(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      type: type ?? this.type,
+      planned: planned ?? this.planned,
+      currency: currency ?? this.currency,
+      parentId: parentId ?? this.parentId,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'name': name,
+    'type': type.name,
+    'planned': planned,
+    'currency': currency,
+    'parentId': parentId,
+  };
+
+  factory EnvelopeDef.fromJson(Map<String, dynamic> j) => EnvelopeDef(
+    id: j['id'] as String,
+    name: j['name'] as String,
+    type: ((j['type'] as String) == 'income') ? EnvelopeType.income : EnvelopeType.expense,
+    planned: (j['planned'] as num).toDouble(),
+    currency: (j['currency'] as String).toUpperCase(),
+    parentId: j['parentId'] as String?,
+  );
+}
+
+class EnvelopeSpend {
+  final EnvelopeDef def;
+  final double spent; // always expressed in monthly currency
+  EnvelopeSpend({required this.def, required this.spent});
+
+  double get remaining => (def.planned - spent);
+  double get pct => def.planned <= 0 ? 0 : (spent / def.planned).clamp(0, 1);
+}
+

--- a/travel_planner_app/lib/screens/app_shell.dart
+++ b/travel_planner_app/lib/screens/app_shell.dart
@@ -99,7 +99,7 @@ class _AppShellState extends State<AppShell> {
           NavigationDestination(icon: Icon(Icons.dashboard_outlined), label: 'Home'),
           NavigationDestination(icon: Icon(Icons.receipt_long_outlined), label: 'Expenses'),
           NavigationDestination(icon: Icon(Icons.savings_outlined), label: 'Budgets'),
-          NavigationDestination(icon: Icon(Icons.pie_chart_outline), label: 'Monthly'), // 👈 NEW
+          NavigationDestination(icon: Icon(Icons.calendar_month_outlined), label: 'Monthly'), // 👈 NEW
         ],
       ),
     );

--- a/travel_planner_app/lib/screens/monthly_budget_screen.dart
+++ b/travel_planner_app/lib/screens/monthly_budget_screen.dart
@@ -1,72 +1,222 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
-import '../models/monthly.dart';
+import '../services/monthly_service.dart';
+import '../services/envelope_store.dart';
+import '../services/envelope_links_store.dart';
+import '../models/envelope.dart';
+import '../models/budget.dart';
 
 class MonthlyBudgetScreen extends StatefulWidget {
   final ApiService api;
   const MonthlyBudgetScreen({super.key, required this.api});
-
   @override
   State<MonthlyBudgetScreen> createState() => _MonthlyBudgetScreenState();
 }
 
 class _MonthlyBudgetScreenState extends State<MonthlyBudgetScreen> {
-  DateTime _month = DateTime(DateTime.now().year, DateTime.now().month);
-  late Future<List<dynamic>> _future; // [summary, envelopes]
+  late DateTime _month; // normalized to 1st day
+  late MonthlyService _svc;
+  late Future<({MonthlyBudgetSummary summary, List<EnvelopeSpend> envelopes})> _future;
 
   @override
   void initState() {
     super.initState();
-    _future = _load();
+    _month = DateTime(DateTime.now().year, DateTime.now().month, 1);
+    _svc = MonthlyService(widget.api);
+    _future = _svc.load(_month);
   }
 
-  Future<List<dynamic>> _load() async {
-    final summary = await widget.api.fetchMonthlySummary(_month);
-    final envs = await widget.api.fetchMonthlyEnvelopes(_month);
-    return [summary, envs];
+  void _reload() {
+    setState(() => _future = _svc.load(_month));
   }
 
   Future<void> _pickMonth() async {
-    final base = DateTime(_month.year, _month.month);
-    final options = List.generate(13, (i) {
-      final d = DateTime(base.year, base.month - 6 + i);
-      return DateTime(d.year, d.month);
-    });
     final picked = await showModalBottomSheet<DateTime>(
       context: context,
       showDragHandle: true,
-      builder: (ctx) => ListView(
-        children: [
-          for (final d in options)
-            ListTile(
-              title: Text('${_mmm(d.month)} ${d.year}'),
-              onTap: () => Navigator.pop(ctx, d),
-            )
-        ],
-      ),
+      builder: (ctx) {
+        final base = _month;
+        final months = List.generate(13, (i) {
+          final d = DateTime(base.year, base.month - 6 + i, 1);
+          return d;
+        });
+        return ListView(
+          children: months
+              .map((m) => ListTile(
+                    title: Text('${_name(m.month)} ${m.year}'),
+                    onTap: () => Navigator.pop(ctx, m),
+                  ))
+              .toList(),
+        );
+      },
     );
     if (picked != null) {
       setState(() {
-        _month = picked;
-        _future = _load();
+        _month = DateTime(picked.year, picked.month, 1);
+        _future = _svc.load(_month);
       });
     }
   }
 
-  String _mmm(int m) => const [
-        'Jan',
-        'Feb',
-        'Mar',
-        'Apr',
-        'May',
-        'Jun',
-        'Jul',
-        'Aug',
-        'Sep',
-        'Oct',
-        'Nov',
-        'Dec'
-      ][m - 1];
+  String _name(int m) => const [
+    'Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'
+  ][(m - 1) % 12];
+
+  Future<void> _addEnvelope({String? parentId}) async {
+    EnvelopeType type = parentId == null ? EnvelopeType.expense : EnvelopeType.expense;
+    final name = TextEditingController();
+    final planned = TextEditingController(text: '0');
+    final isIncome = ValueNotifier<bool>(false);
+
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(parentId == null ? 'New Category' : 'New Sub‑category'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(controller: name, decoration: const InputDecoration(labelText: 'Name')),
+            const SizedBox(height: 8),
+            TextField(
+              controller: planned,
+              decoration: const InputDecoration(labelText: 'Planned (Home currency)'),
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            ),
+            if (parentId == null) ...[
+              const SizedBox(height: 8),
+              ValueListenableBuilder<bool>(
+                valueListenable: isIncome,
+                builder: (_, v, __) => CheckboxListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('This is Income (e.g., Salary)'),
+                  value: v,
+                  onChanged: (x) => isIncome.value = x ?? false,
+                ),
+              ),
+            ],
+          ],
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Save')),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    final id = 'env_${DateTime.now().millisecondsSinceEpoch}_${Random().nextInt(9999)}';
+    final env = EnvelopeDef(
+      id: id,
+      name: name.text.trim(),
+      type: parentId == null
+          ? (isIncome.value ? EnvelopeType.income : EnvelopeType.expense)
+          : EnvelopeType.expense,
+      planned: double.tryParse(planned.text.trim()) ?? 0,
+      currency: (await _svc.api.convert(amount: 0, from: 'EUR', to: 'EUR')) != 0 ? 'EUR' : 'EUR', // kept as Home; MonthlyService normalizes
+      parentId: parentId,
+    );
+    await EnvelopeStore.upsert(_month, env);
+    _reload();
+  }
+
+  Future<void> _editEnvelope(EnvelopeDef def) async {
+    final name = TextEditingController(text: def.name);
+    final planned = TextEditingController(text: def.planned.toStringAsFixed(2));
+    EnvelopeType type = def.type;
+
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Edit Envelope'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(controller: name, decoration: const InputDecoration(labelText: 'Name')),
+            const SizedBox(height: 8),
+            TextField(
+              controller: planned,
+              decoration: const InputDecoration(labelText: 'Planned'),
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            ),
+            if (def.parentId == null) ...[
+              const SizedBox(height: 8),
+              DropdownButtonFormField<EnvelopeType>(
+                value: type,
+                items: const [
+                  DropdownMenuItem(value: EnvelopeType.expense, child: Text('Expense')),
+                  DropdownMenuItem(value: EnvelopeType.income,  child: Text('Income')),
+                ],
+                onChanged: (v) => type = v ?? type,
+                decoration: const InputDecoration(labelText: 'Type'),
+              ),
+            ]
+          ],
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Save')),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    await EnvelopeStore.upsert(_month, def.copyWith(
+      name: name.text.trim(),
+      type: def.parentId == null ? type : EnvelopeType.expense,
+      planned: double.tryParse(planned.text.trim()) ?? def.planned,
+    ));
+    _reload();
+  }
+
+  Future<void> _deleteEnvelope(EnvelopeDef def) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete?'),
+        content: const Text('This will remove the category and any sub‑categories.'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Delete')),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    // Load all, drop def and its children
+    final list = await EnvelopeStore.load(_month);
+    final next = list.where((e) => e.id != def.id && e.parentId != def.id).toList();
+    await EnvelopeStore.save(_month, next);
+    _reload();
+  }
+
+  Future<void> _linkTripBudgetToEnvelope(EnvelopeDef env) async {
+    // Load budgets for month, pick one Trip budget that's linked to this month’s Monthly budget
+    final all = await widget.api.fetchBudgetsOrCache();
+    final monthly = all.where((b) => b.kind == BudgetKind.monthly && b.year == _month.year && b.month == _month.month).toList();
+    final monthIds = monthly.map((b) => b.id).toSet();
+    final trips = all.where((b) => b.kind == BudgetKind.trip && b.linkedMonthlyBudgetId != null && monthIds.contains(b.linkedMonthlyBudgetId!)).toList();
+
+    if (trips.isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('No linked trip budgets for this month. Link a trip budget to this month in Budgets first.')));
+      return;
+    }
+
+    final picked = await showDialog<Budget>(
+      context: context,
+      builder: (ctx) => SimpleDialog(
+        title: Text('Link Trip Budget → ${env.name}'),
+        children: [
+          for (final t in trips)
+            SimpleDialogOption(
+              onPressed: () => Navigator.pop(ctx, t),
+              child: Text('${t.name ?? 'Trip'} • ${t.amount.toStringAsFixed(0)} ${t.currency}'),
+            ),
+        ],
+      ),
+    );
+    if (picked == null) return;
+    await EnvelopeLinksStore.setLink(_month, tripBudgetId: picked.id, envelopeId: env.id);
+    _reload();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -76,204 +226,225 @@ class _MonthlyBudgetScreenState extends State<MonthlyBudgetScreen> {
         title: InkWell(
           onTap: _pickMonth,
           child: Row(mainAxisSize: MainAxisSize.min, children: [
-            Text('${_mmm(_month.month)} ${_month.year}'),
+            Text('${_name(_month.month)} ${_month.year}'),
             const SizedBox(width: 6),
             const Icon(Icons.expand_more, size: 18),
           ]),
         ),
+        actions: [
+          IconButton(onPressed: _reload, icon: const Icon(Icons.refresh)),
+        ],
+        centerTitle: true,
       ),
-      body: RefreshIndicator(
-        onRefresh: () async {
-          setState(() => _future = _load());
-          await _future;
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _addEnvelope(),
+        label: const Text('Add Category'),
+        icon: const Icon(Icons.add),
+      ),
+      body: FutureBuilder<({MonthlyBudgetSummary summary, List<EnvelopeSpend> envelopes})>(
+        future: _future,
+        builder: (context, snap) {
+          if (snap.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snap.hasError) {
+            return Center(child: Text('Failed to load: ${snap.error}'));
+          }
+          final data = snap.data!;
+          final summary = data.summary;
+          final envs = data.envelopes;
+
+          // group to parent -> children
+          final parents = envs.where((e) => e.def.parentId == null).toList();
+          final childrenByParent = <String, List<EnvelopeSpend>>{};
+          for (final e in envs.where((e) => e.def.parentId != null)) {
+            childrenByParent.putIfAbsent(e.def.parentId!, () => []).add(e);
+          }
+
+          return ListView(
+            padding: const EdgeInsets.only(bottom: 120),
+            children: [
+              _HeaderCard(summary: summary),
+              const SizedBox(height: 12),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: _LegendRow(pct: summary.pctSpent),
+              ),
+              const SizedBox(height: 12),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: Text('Categories', style: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w800)),
+              ),
+              ...parents.map((p) {
+                final kids = childrenByParent[p.def.id] ?? const <EnvelopeSpend>[];
+                return _EnvelopeCard(
+                  env: p,
+                  children: kids,
+                  onAddSub: () => _addEnvelope(parentId: p.def.id),
+                  onEdit: () => _editEnvelope(p.def),
+                  onDelete: () => _deleteEnvelope(p.def),
+                  onLinkTripBudget: () => _linkTripBudgetToEnvelope(p.def),
+                );
+              }),
+              const SizedBox(height: 16),
+            ],
+          );
         },
-        child: FutureBuilder<List<dynamic>>(
-          future: _future,
-          builder: (context, snap) {
-            if (snap.connectionState == ConnectionState.waiting) {
-              return const Center(child: CircularProgressIndicator());
-            }
-            if (snap.hasError) {
-              return ListView(children: [
-                const SizedBox(height: 100),
-                Center(
-                    child: Text('Could not load monthly view:\n${snap.error}')),
-              ]);
-            }
+      ),
+    );
+  }
+}
 
-            final summary =
-                (snap.data as List)[0] as MonthlyBudgetSummary;
-            final budgets =
-                (snap.data as List)[1] as List<MonthlyEnvelope>;
-            final leftOver = summary.remaining;
-            final pct = summary.pctSpent;
+class _HeaderCard extends StatelessWidget {
+  final MonthlyBudgetSummary summary;
+  const _HeaderCard({required this.summary});
 
-            return ListView(
-              padding: const EdgeInsets.only(bottom: 100),
-              children: [
-                // Overview Card
-                Container(
-                  margin: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-                  padding: const EdgeInsets.all(16),
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).cardColor,
-                    borderRadius: BorderRadius.circular(20),
-                    border: Border.all(color: cs.outlineVariant),
-                  ),
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final pct = summary.pctSpent;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Theme.of(context).cardColor,
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: cs.outlineVariant),
+      ),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              _Ring(value: pct),
+              const SizedBox(width: 16),
+              Expanded(
+                child: DefaultTextStyle(
+                  style: Theme.of(context).textTheme.bodyMedium!,
                   child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Row(
-                        children: [
-                          _Ring(value: pct),
-                          const SizedBox(width: 16),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text('Left Over',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .labelLarge),
-                                const SizedBox(height: 4),
-                                Text(
-                                  leftOver.toStringAsFixed(2),
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .headlineSmall!
-                                      .copyWith(
-                                          fontWeight: FontWeight.w800),
-                                ),
-                                const SizedBox(height: 8),
-                                Text(
-                                    '${(pct * 100).toStringAsFixed(2)}% of income spent',
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .labelMedium!
-                                        .copyWith(
-                                            color: cs.secondary)),
-                              ],
-                            ),
-                          ),
-                        ],
+                      Text('Left Over', style: Theme.of(context).textTheme.labelLarge),
+                      const SizedBox(height: 4),
+                      Text(
+                        '${summary.remaining.toStringAsFixed(2)} ${summary.currency}',
+                        style: Theme.of(context).textTheme.headlineSmall!.copyWith(fontWeight: FontWeight.w800),
                       ),
-                      const SizedBox(height: 12),
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(8),
-                        child: LinearProgressIndicator(
-                          value: pct,
-                          minHeight: 10,
-                          backgroundColor: cs.surfaceVariant,
-                          color: cs.primary,
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      _OverviewStats(
-                        totalBudgeted: summary.totalBudgeted,
-                        totalSpent: summary.totalSpent,
-                        leftOver: leftOver,
+                      const SizedBox(height: 8),
+                      Text(
+                        '${(pct * 100).toStringAsFixed(2)}% of income spent',
+                        style: Theme.of(context).textTheme.labelMedium!.copyWith(color: cs.secondary),
                       ),
                     ],
                   ),
                 ),
-
-                // Envelope rows
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 6),
-                  child: Text('Categories',
-                      style: Theme.of(context)
-                          .textTheme
-                          .titleMedium!
-                          .copyWith(fontWeight: FontWeight.w800)),
-                ),
-                const SizedBox(height: 4),
-                ...budgets.map((b) => _BudgetRow(budget: b)).toList(),
-                const SizedBox(height: 16),
-              ],
-            );
-          },
-        ),
-      ),
-    );
-  }
-}
-
-class _OverviewStats extends StatelessWidget {
-  final double totalBudgeted;
-  final double totalSpent;
-  final double leftOver;
-  const _OverviewStats(
-      {required this.totalBudgeted,
-      required this.totalSpent,
-      required this.leftOver});
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    Widget stat(String label, double amount, Color color) {
-      return Expanded(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(label,
-                style: Theme.of(context)
-                    .textTheme
-                    .labelMedium!
-                    .copyWith(color: cs.secondary)),
-            const SizedBox(height: 4),
-            Text(amount.toStringAsFixed(2),
-                style: Theme.of(context).textTheme.titleMedium),
-          ],
-        ),
-      );
-    }
-
-    return Row(
-      children: [
-        stat('Planned', totalBudgeted, cs.primary),
-        stat('Spent', totalSpent, cs.tertiary),
-        stat('Left', leftOver, cs.primary),
-      ],
-    );
-  }
-}
-
-class _Ring extends StatelessWidget {
-  final double value;
-  const _Ring({required this.value});
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return SizedBox(
-      width: 60,
-      height: 60,
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          CircularProgressIndicator(
-            value: value,
-            strokeWidth: 6,
-            backgroundColor: cs.surfaceVariant,
-            color: cs.primary,
+              ),
+            ],
           ),
-          Center(
-              child: Text('${(value * 100).toStringAsFixed(0)}%',
-                  style: Theme.of(context).textTheme.labelMedium)),
+          const SizedBox(height: 12),
+          const Divider(height: 1),
+          const SizedBox(height: 12),
+          _StatRow(
+            leftLabel: 'Total Budgeted',
+            leftValue: '${summary.totalExpensePlanned.toStringAsFixed(2)} ${summary.currency}',
+            midLabel: 'Spent',
+            midValue:  '${summary.totalSpent.toStringAsFixed(2)} ${summary.currency}',
+            rightLabel: 'Remaining',
+            rightValue: '${summary.remaining.toStringAsFixed(2)} ${summary.currency}',
+          ),
         ],
       ),
     );
   }
 }
 
-class _BudgetRow extends StatelessWidget {
-  final MonthlyEnvelope budget;
-  const _BudgetRow({required this.budget});
+class _EnvelopeCard extends StatelessWidget {
+  final EnvelopeSpend env;
+  final List<EnvelopeSpend> children;
+  final VoidCallback onAddSub;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+  final VoidCallback onLinkTripBudget;
+
+  const _EnvelopeCard({
+    required this.env,
+    required this.children,
+    required this.onAddSub,
+    required this.onEdit,
+    required this.onDelete,
+    required this.onLinkTripBudget,
+  });
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final remaining =
-        (budget.planned - budget.spent).clamp(0.0, double.infinity);
+    final isIncome = env.def.type == EnvelopeType.income;
+    final barColor = isIncome ? cs.tertiary : cs.primary;
+    final pct = env.pct;
+
+    Widget row(EnvelopeSpend e, {bool isChild = false}) {
+      return Padding(
+        padding: EdgeInsets.fromLTRB(isChild ? 40 : 0, 6, 0, 6),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                if (!isChild)
+                  CircleAvatar(
+                    radius: 14,
+                    backgroundColor: barColor.withOpacity(.15),
+                    child: Text(e.def.name.isNotEmpty ? e.def.name[0].toUpperCase() : '?',
+                        style: TextStyle(color: barColor, fontWeight: FontWeight.w900)),
+                  ),
+                if (!isChild) const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(e.def.name, style: const TextStyle(fontWeight: FontWeight.w800)),
+                      const SizedBox(height: 6),
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: LinearProgressIndicator(
+                          value: e.pct,
+                          minHeight: 10,
+                          color: barColor,
+                          backgroundColor: cs.surfaceVariant,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Row(
+                        children: [
+                          Expanded(child: Text('Spending  ${e.spent.toStringAsFixed(2)} ${e.def.currency}', style: Theme.of(context).textTheme.labelSmall)),
+                          Expanded(child: Text('Planned  ${e.def.planned.toStringAsFixed(2)} ${e.def.currency}', textAlign: TextAlign.end, style: Theme.of(context).textTheme.labelSmall)),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                if (!isChild)
+                  PopupMenuButton<String>(
+                    onSelected: (v) {
+                      if (v == 'add_sub') onAddSub();
+                      if (v == 'edit') onEdit();
+                      if (v == 'delete') onDelete();
+                      if (v == 'link_trip') onLinkTripBudget();
+                    },
+                    itemBuilder: (_) => [
+                      const PopupMenuItem(value: 'add_sub', child: Text('Add sub‑category')),
+                      const PopupMenuItem(value: 'edit', child: Text('Edit')),
+                      const PopupMenuItem(value: 'delete', child: Text('Delete')),
+                      const PopupMenuDivider(),
+                      const PopupMenuItem(value: 'link_trip', child: Text('Link Trip Budget')),
+                    ],
+                  ),
+              ],
+            ),
+          ],
+        ),
+      );
+    }
+
     return Container(
       margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
       padding: const EdgeInsets.all(14),
@@ -285,45 +456,102 @@ class _BudgetRow extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Row(
-            children: [
-              Expanded(
-                child: Text(budget.name,
-                    style: Theme.of(context).textTheme.titleMedium),
-              ),
-              const SizedBox(width: 8),
-              Text(budget.planned.toStringAsFixed(2),
-                  style: Theme.of(context)
-                      .textTheme
-                      .labelLarge!
-                      .copyWith(fontWeight: FontWeight.bold)),
-            ],
-          ),
-          const SizedBox(height: 8),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: LinearProgressIndicator(
-              value: budget.pct,
-              minHeight: 8,
-              backgroundColor: cs.surfaceVariant,
-              color: cs.primary,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text('Spent: ${budget.spent.toStringAsFixed(2)}',
-                  style: Theme.of(context).textTheme.labelMedium),
-              Text('Left: ${remaining.toStringAsFixed(2)}',
-                  style: Theme.of(context)
-                      .textTheme
-                      .labelMedium!
-                      .copyWith(color: cs.secondary)),
-            ],
-          ),
+          row(env),
+          for (final c in children) row(c, isChild: true),
         ],
       ),
     );
   }
 }
+
+class _Ring extends StatelessWidget {
+  final double value; // 0..1
+  const _Ring({required this.value});
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return SizedBox(
+      width: 110,
+      height: 110,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          CircularProgressIndicator(value: 1, strokeWidth: 10, color: cs.surfaceVariant),
+          CircularProgressIndicator(value: value, strokeWidth: 10, color: cs.primary),
+          Text('${(value * 100).round()}%',
+              style: Theme.of(context).textTheme.titleMedium!.copyWith(fontWeight: FontWeight.w800)),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatRow extends StatelessWidget {
+  final String leftLabel, leftValue, midLabel, midValue, rightLabel, rightValue;
+  const _StatRow({
+    required this.leftLabel,
+    required this.leftValue,
+    required this.midLabel,
+    required this.midValue,
+    required this.rightLabel,
+    required this.rightValue,
+  });
+  Widget _cell(BuildContext c, String label, String value) {
+    final t = Theme.of(c).textTheme;
+    return Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: t.labelSmall),
+          const SizedBox(height: 2),
+          Text(value, style: t.titleMedium!.copyWith(fontWeight: FontWeight.w700)),
+        ],
+      ),
+    );
+  }
+  @override
+  Widget build(BuildContext context) {
+    return Row(children: [
+      _cell(context, leftLabel, leftValue),
+      _cell(context, midLabel, midValue),
+      _cell(context, rightLabel, rightValue),
+    ]);
+  }
+}
+
+class _LegendRow extends StatelessWidget {
+  final double pct;
+  const _LegendRow({required this.pct});
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Row(
+      children: [
+        _LegendChip(icon: Icons.account_balance_wallet_outlined, label: 'Budget Spent', color: cs.primary),
+        const Spacer(),
+        Text('${(pct * 100).toStringAsFixed(2)}%', style: Theme.of(context).textTheme.labelLarge),
+      ],
+    );
+  }
+}
+
+class _LegendChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color color;
+  const _LegendChip({required this.icon, required this.label, required this.color});
+  @override
+  Widget build(BuildContext context) {
+    final t = Theme.of(context).textTheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(color: color.withOpacity(.15), borderRadius: BorderRadius.circular(8)),
+      child: Row(mainAxisSize: MainAxisSize.min, children: [
+        Icon(icon, size: 16, color: color),
+        const SizedBox(width: 4),
+        Text(label, style: t.labelSmall!.copyWith(fontWeight: FontWeight.w500, color: color)),
+      ]),
+    );
+  }
+}
+

--- a/travel_planner_app/lib/services/envelope_links_store.dart
+++ b/travel_planner_app/lib/services/envelope_links_store.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class EnvelopeLinksStore {
+  // key is month; value is { tripBudgetId: envelopeId }
+  static String _key(DateTime month) {
+    final y = month.year;
+    final m = month.month.toString().padLeft(2, '0');
+    return 'envelope_links_${y}_$m';
+  }
+
+  static Future<Map<String, String>> load(DateTime month) async {
+    final p = await SharedPreferences.getInstance();
+    final s = p.getString(_key(month));
+    if (s == null || s.isEmpty) return <String, String>{};
+    try {
+      final raw = Map<String, dynamic>.from(jsonDecode(s));
+      return raw.map((k, v) => MapEntry(k, v as String));
+    } catch (_) {
+      return <String, String>{};
+    }
+  }
+
+  static Future<void> save(DateTime month, Map<String, String> map) async {
+    final p = await SharedPreferences.getInstance();
+    await p.setString(_key(month), jsonEncode(map));
+  }
+
+  static Future<void> setLink(DateTime month, {required String tripBudgetId, required String envelopeId}) async {
+    final m = await load(month);
+    m[tripBudgetId] = envelopeId;
+    await save(month, m);
+  }
+
+  static Future<void> unlink(DateTime month, String tripBudgetId) async {
+    final m = await load(month);
+    m.remove(tripBudgetId);
+    await save(month, m);
+  }
+}
+

--- a/travel_planner_app/lib/services/envelope_store.dart
+++ b/travel_planner_app/lib/services/envelope_store.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/envelope.dart';
+
+class EnvelopeStore {
+  static String _key(DateTime month) {
+    final y = month.year;
+    final m = month.month.toString().padLeft(2, '0');
+    return 'envelopes_${y}_$m';
+  }
+
+  // Load the envelope definitions for a month
+  static Future<List<EnvelopeDef>> load(DateTime month) async {
+    final p = await SharedPreferences.getInstance();
+    final s = p.getString(_key(month));
+    if (s == null || s.isEmpty) return <EnvelopeDef>[];
+    try {
+      final raw = (jsonDecode(s) as List).cast<Map<String, dynamic>>();
+      return raw.map(EnvelopeDef.fromJson).toList();
+    } catch (_) {
+      return <EnvelopeDef>[];
+    }
+  }
+
+  // Save/replace the list for a month
+  static Future<void> save(DateTime month, List<EnvelopeDef> items) async {
+    final p = await SharedPreferences.getInstance();
+    await p.setString(
+      _key(month),
+      jsonEncode(items.map((e) => e.toJson()).toList()),
+    );
+  }
+
+  // Helpers
+  static Future<void> upsert(DateTime month, EnvelopeDef def) async {
+    final list = await load(month);
+    final next = [
+      ...list.where((e) => e.id != def.id),
+      def,
+    ];
+    await save(month, next);
+  }
+
+  static Future<void> remove(DateTime month, String id) async {
+    final list = await load(month);
+    await save(month, list.where((e) => e.id != id).toList());
+  }
+}
+

--- a/travel_planner_app/lib/services/monthly_service.dart
+++ b/travel_planner_app/lib/services/monthly_service.dart
@@ -1,0 +1,125 @@
+import 'package:hive/hive.dart';
+import '../models/expense.dart';
+import '../models/envelope.dart';
+import '../models/budget.dart';
+import '../services/api_service.dart';
+import '../services/envelope_store.dart';
+import '../services/envelope_links_store.dart';
+import '../services/prefs_service.dart';
+
+class MonthlyBudgetSummary {
+  final String currency;          // monthly currency (home)
+  final double totalIncomePlanned;
+  final double totalExpensePlanned;
+  final double totalSpent;
+  MonthlyBudgetSummary({
+    required this.currency,
+    required this.totalIncomePlanned,
+    required this.totalExpensePlanned,
+    required this.totalSpent,
+  });
+
+  double get remaining => (totalExpensePlanned - totalSpent);
+  double get pctSpent => (totalIncomePlanned <= 0)
+      ? (totalExpensePlanned <= 0 ? 0 : (totalSpent / totalExpensePlanned))
+      : (totalSpent / totalIncomePlanned);
+}
+
+class MonthlyService {
+  final ApiService api;
+  MonthlyService(this.api);
+
+  // Compute envelopes + summary for a month
+  // month is any date within that month (year/month used)
+  Future<({
+    MonthlyBudgetSummary summary,
+    List<EnvelopeSpend> envelopes,
+  })> load(DateTime month) async {
+    final monthlyCurrency = await PrefsService.getHomeCurrency();
+
+    // 1) Load envelope definitions (planned)
+    final defs = await EnvelopeStore.load(month);
+
+    // 2) Gather spent from local expenses by month (Hive)
+    final box = Hive.box<Expense>('expensesBox');
+    final start = DateTime(month.year, month.month);
+    final end = DateTime(month.year, month.month + 1);
+    final monthExpenses = box.values.where((e) => e.date.isAfter(start.subtract(const Duration(milliseconds: 1))) && e.date.isBefore(end)).toList();
+
+    // Sum spent per category (case-insensitive name match)
+    final spendByName = <String, double>{}; // in monthlyCurrency
+    for (final e in monthExpenses) {
+      final from = (e.currency.isEmpty) ? monthlyCurrency : e.currency.toUpperCase();
+      final to = monthlyCurrency.toUpperCase();
+      final converted = (from == to)
+          ? e.amount
+          : await api.convert(amount: e.amount, from: from, to: to);
+      final key = e.category.trim().toLowerCase();
+      spendByName[key] = (spendByName[key] ?? 0) + converted;
+    }
+
+    // 3) Pull Trip budgets that are *linked to this month* via your existing Monthly budgets
+    // We inspect your /budgets to find monthly budgets for this month,
+    // then include Trip budgets whose linkedMonthlyBudgetId matches.
+    final allBudgets = await api.fetchBudgetsOrCache();
+    final monthlyBudgets = allBudgets.where((b) =>
+      b.kind == BudgetKind.monthly && b.year == month.year && b.month == month.month
+    ).toList();
+    final monthlyIds = monthlyBudgets.map((b) => b.id).toSet();
+    final tripBudgetsForThisMonth = allBudgets.where((b) =>
+      b.kind == BudgetKind.trip && b.linkedMonthlyBudgetId != null && monthlyIds.contains(b.linkedMonthlyBudgetId!)
+    ).toList();
+
+    // 4) Use EnvelopeLinks to attribute Trip budget *planned* into an envelope
+    final links = await EnvelopeLinksStore.load(month); // { tripBudgetId: envelopeId }
+    final plannedBumps = <String, double>{}; // envelopeId -> amount to add
+    for (final tb in tripBudgetsForThisMonth) {
+      final envelopeId = links[tb.id];
+      if (envelopeId == null) continue;
+      // convert Trip budget amount to monthly currency
+      final to = monthlyCurrency.toUpperCase();
+      final from = tb.currency.toUpperCase();
+      final bump = (from == to)
+          ? tb.amount
+          : await api.convert(amount: tb.amount, from: from, to: to);
+      plannedBumps[envelopeId] = (plannedBumps[envelopeId] ?? 0) + bump;
+    }
+
+    // 5) Build EnvelopeSpend list (planned may include linked trip budgets)
+    final envSpends = <EnvelopeSpend>[];
+    for (final d in defs) {
+      // normalize planned into monthlyCurrency (definitions should already be in home)
+      final plannedInMonthly = (d.currency.toUpperCase() == monthlyCurrency.toUpperCase())
+          ? d.planned
+          : await api.convert(amount: d.planned, from: d.currency, to: monthlyCurrency);
+
+      final bump = plannedBumps[d.id] ?? 0.0;
+      final spent = spendByName[d.name.trim().toLowerCase()] ?? 0.0;
+      envSpends.add(EnvelopeSpend(
+        def: d.copyWith(planned: plannedInMonthly + bump, currency: monthlyCurrency),
+        spent: spent,
+      ));
+    }
+
+    // 6) Totals
+    final totalIncomePlanned = envSpends
+        .where((e) => e.def.type == EnvelopeType.income)
+        .fold<double>(0.0, (p, e) => p + e.def.planned);
+    final totalExpensePlanned = envSpends
+        .where((e) => e.def.type == EnvelopeType.expense)
+        .fold<double>(0.0, (p, e) => p + e.def.planned);
+    final totalSpent = envSpends
+        .where((e) => e.def.type == EnvelopeType.expense) // we only count expense spend
+        .fold<double>(0.0, (p, e) => p + e.spent);
+
+    final summary = MonthlyBudgetSummary(
+      currency: monthlyCurrency,
+      totalIncomePlanned: totalIncomePlanned,
+      totalExpensePlanned: totalExpensePlanned,
+      totalSpent: totalSpent,
+    );
+
+    return (summary: summary, envelopes: envSpends);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add envelope models and local stores for monthly categories
- compute monthly summaries and trip-budget links via new service
- replace monthly budget UI with envelope progress and overview card

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d34915408327b3609d40bc63106f