### PR TITLE
Add monthly budget models and endpoints

### DIFF
--- a/travel_planner_app/lib/models/monthly.dart
+++ b/travel_planner_app/lib/models/monthly.dart
@@ -1,46 +1,47 @@
-// monthly.dart start
-// 👇 NEW: Monthly overview + envelopes data models
 class MonthlyBudgetSummary {
-  final String currency;        // e.g., 'EUR'
-  final double totalBudgeted;   // sum of all monthly budgets (in their own ccy converted to currency)
-  final double totalSpent;      // sum of linked trip spends converted to currency
-  final double remaining;       // totalBudgeted - totalSpent
-  final double pctSpent;        // clamp 0..1
+  final String currency;
+  final double totalBudgeted;
+  final double totalSpent;
+  double get remaining => (totalBudgeted - totalSpent);
+  double get pctSpent => totalBudgeted <= 0 ? 0 : (totalSpent / totalBudgeted);
 
   const MonthlyBudgetSummary({
     required this.currency,
     required this.totalBudgeted,
     required this.totalSpent,
-    required this.remaining,
-    required this.pctSpent,
   });
+
+  factory MonthlyBudgetSummary.fromJson(Map<String, dynamic> j) => MonthlyBudgetSummary(
+    currency: (j['currency'] ?? 'EUR') as String,
+    totalBudgeted: (j['totalBudgeted'] as num).toDouble(),
+    totalSpent: (j['totalSpent'] as num).toDouble(),
+  );
 }
 
-class MonthlyEnvelope {
-  final String id;              // stable id (can reuse budget id)
-  final String name;            // e.g., 'Food' or 'Income: Salary'
-  final String currency;        // envelope currency (usually same as monthly currency)
-  final double planned;         // budgeted amount
-  final double spent;           // computed spent
-  final int colorIndex;         // for row color variation
-  final List<MonthlyEnvelope> children; // optional sub-categories
+class MonthlyCategory {
+  final String id;
+  final String name;
+  final String currency;
+  final double planned; // budgeted
+  final double spent;   // aggregated
+  final int colorIndex;
+  double get pct => planned <= 0 ? 0 : (spent / planned).clamp(0, 1);
 
-  const MonthlyEnvelope({
+  const MonthlyCategory({
     required this.id,
     required this.name,
     required this.currency,
     required this.planned,
     required this.spent,
     this.colorIndex = 0,
-    this.children = const <MonthlyEnvelope>[],
   });
 
-  double get pct {
-    if (planned <= 0) return 0;
-    final p = spent / planned;
-    if (p < 0) return 0;
-    if (p > 1.0) return 1.0;
-    return p;
-  }
+  factory MonthlyCategory.fromJson(Map<String, dynamic> j) => MonthlyCategory(
+    id: j['id'] as String,
+    name: j['name'] as String,
+    currency: (j['currency'] ?? 'EUR') as String,
+    planned: (j['planned'] as num).toDouble(),
+    spent: (j['spent'] as num).toDouble(),
+    colorIndex: (j['colorIndex'] ?? 0) as int,
+  );
 }
-// monthly.dart end

--- a/travel_planner_app/lib/screens/budgets_screen.dart
+++ b/travel_planner_app/lib/screens/budgets_screen.dart
@@ -6,7 +6,7 @@ import '../models/budget.dart';
 import '../services/budgets_sync.dart';
 import '../services/archived_trips_store.dart';
 import '../services/outbox_service.dart';
-import 'monthly_overview_screen.dart';
+import 'monthly_budget_screen.dart';
 
 class BudgetsScreen extends StatefulWidget {
   const BudgetsScreen({super.key, required this.api});
@@ -572,12 +572,11 @@ class _BudgetsScreenState extends State<BudgetsScreen> with TickerProviderStateM
             },
           ),
           IconButton(
-            icon: const Icon(Icons.calendar_view_month_outlined),
+            icon: const Icon(Icons.calendar_month_outlined),
             tooltip: 'Monthly',
             onPressed: () {
               Navigator.of(context).push(
-                MaterialPageRoute(
-                    builder: (_) => MonthlyOverviewScreen(api: widget.api)),
+                MaterialPageRoute(builder: (_) => MonthlyBudgetScreen(api: widget.api)),
               );
             },
           ),


### PR DESCRIPTION
## Summary
- add lightweight MonthlyBudgetSummary and MonthlyCategory models
- provide network-first fetchMonthlySummary and fetchMonthlyBudgets in ApiService
- link Budgets screen to MonthlyBudgetScreen via app bar icon

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e3beb73083278a5eccbabcde733b