### PR TITLE
feat: add categories and monthly transactions

### DIFF
--- a/travel_planner_app/lib/models/monthly.dart
+++ b/travel_planner_app/lib/models/monthly.dart
@@ -22,13 +22,18 @@ class EnvelopeVM {
 class MonthlyBudgetSummary {
   final String currency;      // summary currency (monthly currency)
   final double totalBudgeted; // sum(planned)
-  final double totalSpent;    // sum(spent)
+  final double totalSpent;    // trip-linked + monthly expenses
+  final double totalIncome;      // salary etc. (in monthly currency)
+  final double totalMonthExpenses;
+
   MonthlyBudgetSummary({
     required this.currency,
     required this.totalBudgeted,
     required this.totalSpent,
+    this.totalIncome = 0.0,
+    this.totalMonthExpenses = 0.0,
   });
-  double get remaining => (totalBudgeted - totalSpent);
+  double get remaining => (totalBudgeted + totalIncome) - totalSpent;
   double get pctSpent => totalBudgeted <= 0 ? 0.0 : (totalSpent / totalBudgeted).clamp(0.0, 1.0);
 }
 // MonthlyBudgetSummary end

--- a/travel_planner_app/lib/models/monthly_txn.dart
+++ b/travel_planner_app/lib/models/monthly_txn.dart
@@ -1,0 +1,52 @@
+// models/monthly_txn.dart
+// ▷ MonthlyTxn model start
+enum MonthlyTxnKind { income, expense }
+
+class MonthlyTxn {
+  final String id;
+  final String monthKey;        // "2025-08"
+  final MonthlyTxnKind kind;    // income | expense
+  final String currency;        // ISO 4217
+  final double amount;
+  final DateTime date;
+  final String? categoryId;     // from CategoryStore (root)
+  final String? subcategoryId;  // optional sub
+  final String? note;
+
+  MonthlyTxn({
+    required this.id,
+    required this.monthKey,
+    required this.kind,
+    required this.currency,
+    required this.amount,
+    required this.date,
+    this.categoryId,
+    this.subcategoryId,
+    this.note,
+  });
+
+  factory MonthlyTxn.fromJson(Map<String, dynamic> j) => MonthlyTxn(
+        id: j['id'],
+        monthKey: j['monthKey'],
+        kind: (j['kind'] == 'income') ? MonthlyTxnKind.income : MonthlyTxnKind.expense,
+        currency: j['currency'],
+        amount: (j['amount'] as num).toDouble(),
+        date: DateTime.parse(j['date']),
+        categoryId: j['categoryId'],
+        subcategoryId: j['subcategoryId'],
+        note: j['note'],
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'monthKey': monthKey,
+        'kind': kind == MonthlyTxnKind.income ? 'income' : 'expense',
+        'currency': currency,
+        'amount': amount,
+        'date': date.toIso8601String(),
+        'categoryId': categoryId,
+        'subcategoryId': subcategoryId,
+        'note': note,
+      };
+}
+// ◀ MonthlyTxn model end

--- a/travel_planner_app/lib/services/monthly_store.dart
+++ b/travel_planner_app/lib/services/monthly_store.dart
@@ -1,67 +1,36 @@
+// services/monthly_store.dart
+// ▷ MonthlyStore start
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
-import '../models/monthly_category.dart';
+import '../models/monthly_txn.dart';
+
+String monthKeyOf(DateTime d) => '${d.year}-${d.month.toString().padLeft(2, '0')}';
 
 class MonthlyStore {
-  static String _key(DateTime month) =>
-      'monthly_envelopes_${month.year}_${month.month.toString().padLeft(2, '0')}';
+  static String _k(String monthKey) => 'monthly_txns_$monthKey';
 
-  /// Load envelopes (Income + Expense) for a month.
-  static Future<List<MonthlyCategory>> load(DateTime month) async {
+  static Future<List<MonthlyTxn>> all(String monthKey) async {
     final p = await SharedPreferences.getInstance();
-    final s = p.getString(_key(month));
-    if (s == null || s.isEmpty) return _seed(month);
-    try {
-      final raw = (jsonDecode(s) as List).cast<Map<String, dynamic>>();
-      return raw.map(MonthlyCategory.fromJson).toList();
-    } catch (_) {
-      return _seed(month);
-    }
+    final s = p.getString(_k(monthKey));
+    if (s == null || s.isEmpty) return <MonthlyTxn>[];
+    final list = (jsonDecode(s) as List).cast<Map<String, dynamic>>();
+    return list.map(MonthlyTxn.fromJson).toList();
   }
 
-  /// Save the full set for the month.
-  static Future<void> save(DateTime month, List<MonthlyCategory> list) async {
+  static Future<void> _save(String monthKey, List<MonthlyTxn> list) async {
     final p = await SharedPreferences.getInstance();
-    await p.setString(
-      _key(month),
-      jsonEncode(list.map((e) => e.toJson()).toList()),
-    );
+    await p.setString(_k(monthKey), jsonEncode(list.map((e) => e.toJson()).toList()));
   }
 
-  /// First‑time defaults (you can tweak freely)
-  static List<MonthlyCategory> _seed(DateTime month) {
-    return [
-      MonthlyCategory(
-        id: 'cat_income_salary',
-        kind: MonthlyKind.income,
-        name: 'Salary',
-        currency: 'EUR',
-        subs: [MonthlySubcategory(id: 'sub_base', name: 'Base', planned: 0)],
-      ),
-      MonthlyCategory(
-        id: 'cat_exp_food',
-        kind: MonthlyKind.expense,
-        name: 'Food',
-        currency: 'EUR',
-        subs: [
-          MonthlySubcategory(
-              id: 'sub_groceries', name: 'Groceries', planned: 200),
-          MonthlySubcategory(
-              id: 'sub_eatingout', name: 'Eating out', planned: 150),
-        ],
-      ),
-      MonthlyCategory(
-        id: 'cat_exp_transport',
-        kind: MonthlyKind.expense,
-        name: 'Transport',
-        currency: 'EUR',
-        subs: [
-          MonthlySubcategory(
-              id: 'sub_public', name: 'Public', planned: 50),
-          MonthlySubcategory(
-              id: 'sub_ride', name: 'Ride-hailing', planned: 50),
-        ],
-      ),
-    ];
+  static Future<void> add(String monthKey, MonthlyTxn txn) async {
+    final list = await all(monthKey);
+    final next = [...list.where((t) => t.id != txn.id), txn];
+    await _save(monthKey, next);
+  }
+
+  static Future<void> delete(String monthKey, String id) async {
+    final list = await all(monthKey);
+    await _save(monthKey, list.where((t) => t.id != id).toList());
   }
 }
+// ◀ MonthlyStore end


### PR DESCRIPTION
## Summary
- add `MonthlyTxn` model and persistence store
- extend monthly budget summary with income and manual expenses
- update monthly budget UI to manage categories and add monthly income/expenses

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a5ff38808327a5e4c3cce30fbe44