### PR TITLE
Add Hive-backed monthly categories and transactions UI

### DIFF
--- a/travel_planner_app/lib/main.dart
+++ b/travel_planner_app/lib/main.dart
@@ -6,6 +6,7 @@ import 'screens/app_shell.dart';
 import 'services/api_service.dart';
 import 'services/trip_storage_service.dart';
 import 'services/hive_migrations.dart';
+import 'services/monthly_store.dart';
 
 
 Future<void> main() async {
@@ -19,6 +20,8 @@ Future<void> main() async {
   await Hive.deleteBoxFromDisk('expensesBox');
   await Hive.openBox<Expense>('expensesBox');
   await HiveMigrations.backfillExpenseCurrency();
+  // 👇 NEW: Monthly store init (place next to your other Hive inits)
+  await MonthlyStore.instance.init();
   // Trip storage init
   await TripStorageService.init();
 

--- a/travel_planner_app/lib/models/monthly_category.dart
+++ b/travel_planner_app/lib/models/monthly_category.dart
@@ -1,83 +1,36 @@
-class MonthlySubcategory {
-  final String id;
-  final String name;
-  final double planned; // planned amount for the month
-  MonthlySubcategory({
-    required this.id,
-    required this.name,
-    this.planned = 0,
-  });
+// ===== monthly_category.dart — START =====
+// Description: Hive model for Monthly Category. Supports sub-categories via parentId.
+// TypeId: pick a free one; keep unique across your app. Example: 41.
 
-  MonthlySubcategory copyWith({String? id, String? name, double? planned}) =>
-      MonthlySubcategory(
-        id: id ?? this.id,
-        name: name ?? this.name,
-        planned: planned ?? this.planned,
-      );
+import 'package:hive/hive.dart';
 
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'planned': planned,
-      };
-  factory MonthlySubcategory.fromJson(Map<String, dynamic> j) =>
-      MonthlySubcategory(
-        id: j['id'] as String,
-        name: j['name'] as String,
-        planned: (j['planned'] as num?)?.toDouble() ?? 0,
-      );
-}
+part 'monthly_category.g.dart';
 
-enum MonthlyKind { income, expense }
+@HiveType(typeId: 41) // 👈 NEW: ensure this does not clash with existing adapters
+class MonthlyCategory extends HiveObject {
+  @HiveField(0)
+  String id; // uuid
 
-class MonthlyCategory {
-  final String id;
-  final MonthlyKind kind;
-  final String name; // e.g. “Food”, “Salary”
-  final String currency; // envelope currency (usually your monthly base)
-  final List<MonthlySubcategory> subs;
+  @HiveField(1)
+  String name;
+
+  @HiveField(2)
+  String monthKey; // 'YYYY-MM' e.g., '2025-08'
+
+  @HiveField(3)
+  String type; // 'income' | 'expense'
+
+  @HiveField(4)
+  String? parentId; // if set => sub-category of that category
 
   MonthlyCategory({
     required this.id,
-    required this.kind,
     required this.name,
-    required this.currency,
-    this.subs = const [],
+    required this.monthKey,
+    required this.type,
+    this.parentId,
   });
 
-  MonthlyCategory copyWith({
-    String? id,
-    MonthlyKind? kind,
-    String? name,
-    String? currency,
-    List<MonthlySubcategory>? subs,
-  }) =>
-      MonthlyCategory(
-        id: id ?? this.id,
-        kind: kind ?? this.kind,
-        name: name ?? this.name,
-        currency: currency ?? this.currency,
-        subs: subs ?? this.subs,
-      );
-
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'kind': kind.name,
-        'name': name,
-        'currency': currency,
-        'subs': subs.map((s) => s.toJson()).toList(),
-      };
-
-  factory MonthlyCategory.fromJson(Map<String, dynamic> j) => MonthlyCategory(
-        id: j['id'] as String,
-        kind: (j['kind'] as String) == 'income'
-            ? MonthlyKind.income
-            : MonthlyKind.expense,
-        name: j['name'] as String,
-        currency: (j['currency'] as String?) ?? 'EUR',
-        subs: ((j['subs'] as List?) ?? const [])
-            .map((e) => MonthlySubcategory.fromJson(
-                Map<String, dynamic>.from(e as Map)))
-            .toList(),
-      );
+  bool get isSub => parentId != null;
 }
+// ===== monthly_category.dart — END =====

--- a/travel_planner_app/lib/models/monthly_category.g.dart
+++ b/travel_planner_app/lib/models/monthly_category.g.dart
@@ -1,0 +1,41 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'monthly_category.dart';
+
+class MonthlyCategoryAdapter extends TypeAdapter<MonthlyCategory> {
+  @override
+  final int typeId = 41;
+
+  @override
+  MonthlyCategory read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{};
+    for (var i = 0; i < numOfFields; i++) {
+      final key = reader.readByte();
+      fields[key] = reader.read();
+    }
+    return MonthlyCategory(
+      id: fields[0] as String,
+      name: fields[1] as String,
+      monthKey: fields[2] as String,
+      type: fields[3] as String,
+      parentId: fields[4] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, MonthlyCategory obj) {
+    writer
+      ..writeByte(5)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.name)
+      ..writeByte(2)
+      ..write(obj.monthKey)
+      ..writeByte(3)
+      ..write(obj.type)
+      ..writeByte(4)
+      ..write(obj.parentId);
+  }
+}

--- a/travel_planner_app/lib/models/monthly_txn.dart
+++ b/travel_planner_app/lib/models/monthly_txn.dart
@@ -1,52 +1,46 @@
-// models/monthly_txn.dart
-// ▷ MonthlyTxn model start
-enum MonthlyTxnKind { income, expense }
+// ===== monthly_txn.dart — START =====
+// Description: Hive model for Monthly Transactions (salary & expenses) tracked per month.
+// TypeId: pick a free one; example: 42.
 
-class MonthlyTxn {
-  final String id;
-  final String monthKey;        // "2025-08"
-  final MonthlyTxnKind kind;    // income | expense
-  final String currency;        // ISO 4217
-  final double amount;
-  final DateTime date;
-  final String? categoryId;     // from CategoryStore (root)
-  final String? subcategoryId;  // optional sub
-  final String? note;
+import 'package:hive/hive.dart';
+
+part 'monthly_txn.g.dart';
+
+@HiveType(typeId: 42)
+class MonthlyTxn extends HiveObject {
+  @HiveField(0)
+  String id; // uuid
+
+  @HiveField(1)
+  String monthKey; // 'YYYY-MM'
+
+  @HiveField(2)
+  String categoryId; // link to MonthlyCategory (can be sub-category)
+
+  @HiveField(3)
+  double amount;
+
+  @HiveField(4)
+  String currency; // store entered currency
+
+  @HiveField(5)
+  String note;
+
+  @HiveField(6)
+  DateTime date;
+
+  @HiveField(7)
+  String type; // 'income' | 'expense' (redundant but handy for queries)
 
   MonthlyTxn({
     required this.id,
     required this.monthKey,
-    required this.kind,
-    required this.currency,
+    required this.categoryId,
     required this.amount,
+    required this.currency,
+    required this.note,
     required this.date,
-    this.categoryId,
-    this.subcategoryId,
-    this.note,
+    required this.type,
   });
-
-  factory MonthlyTxn.fromJson(Map<String, dynamic> j) => MonthlyTxn(
-        id: j['id'],
-        monthKey: j['monthKey'],
-        kind: (j['kind'] == 'income') ? MonthlyTxnKind.income : MonthlyTxnKind.expense,
-        currency: j['currency'],
-        amount: (j['amount'] as num).toDouble(),
-        date: DateTime.parse(j['date']),
-        categoryId: j['categoryId'],
-        subcategoryId: j['subcategoryId'],
-        note: j['note'],
-      );
-
-  Map<String, dynamic> toJson() => {
-        'id': id,
-        'monthKey': monthKey,
-        'kind': kind == MonthlyTxnKind.income ? 'income' : 'expense',
-        'currency': currency,
-        'amount': amount,
-        'date': date.toIso8601String(),
-        'categoryId': categoryId,
-        'subcategoryId': subcategoryId,
-        'note': note,
-      };
 }
-// ◀ MonthlyTxn model end
+// ===== monthly_txn.dart — END =====

--- a/travel_planner_app/lib/models/monthly_txn.g.dart
+++ b/travel_planner_app/lib/models/monthly_txn.g.dart
@@ -1,0 +1,50 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'monthly_txn.dart';
+
+class MonthlyTxnAdapter extends TypeAdapter<MonthlyTxn> {
+  @override
+  final int typeId = 42;
+
+  @override
+  MonthlyTxn read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{};
+    for (var i = 0; i < numOfFields; i++) {
+      final key = reader.readByte();
+      fields[key] = reader.read();
+    }
+    return MonthlyTxn(
+      id: fields[0] as String,
+      monthKey: fields[1] as String,
+      categoryId: fields[2] as String,
+      amount: fields[3] as double,
+      currency: fields[4] as String,
+      note: fields[5] as String,
+      date: fields[6] as DateTime,
+      type: fields[7] as String,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, MonthlyTxn obj) {
+    writer
+      ..writeByte(8)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.monthKey)
+      ..writeByte(2)
+      ..write(obj.categoryId)
+      ..writeByte(3)
+      ..write(obj.amount)
+      ..writeByte(4)
+      ..write(obj.currency)
+      ..writeByte(5)
+      ..write(obj.note)
+      ..writeByte(6)
+      ..write(obj.date)
+      ..writeByte(7)
+      ..write(obj.type);
+  }
+}

--- a/travel_planner_app/lib/screens/monthly/category_editor_sheet.dart
+++ b/travel_planner_app/lib/screens/monthly/category_editor_sheet.dart
@@ -1,0 +1,79 @@
+// ===== category_editor_sheet.dart — START =====
+// Description: Modal to create category or sub-category for a given month.
+
+import 'package:flutter/material.dart';
+import '../../services/monthly_store.dart';
+import '../../models/monthly_category.dart';
+
+class CategoryEditorSheet extends StatefulWidget {
+  final String monthKey;
+  final String type; // 'income' | 'expense'
+  final MonthlyCategory? parent; // if provided -> creating a sub-category
+
+  const CategoryEditorSheet({
+    super.key,
+    required this.monthKey,
+    required this.type,
+    this.parent,
+  });
+
+  @override
+  State<CategoryEditorSheet> createState() => _CategoryEditorSheetState();
+}
+
+class _CategoryEditorSheetState extends State<CategoryEditorSheet> {
+  final _ctrl = TextEditingController();
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (_ctrl.text.trim().isEmpty) return;
+    setState(() => _saving = true);
+    await MonthlyStore.instance.addCategory(
+      name: _ctrl.text,
+      monthKey: widget.monthKey,
+      type: widget.type,
+      parentId: widget.parent?.id,
+    );
+    if (mounted) Navigator.pop(context, true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final label = widget.parent == null
+        ? 'New ${widget.type} category'
+        : 'New sub-category of "${widget.parent!.name}"';
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+      child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(label, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _ctrl,
+              decoration: const InputDecoration(labelText: 'Name'),
+              autofocus: true,
+              onSubmitted: (_) => _save(),
+            ),
+            const SizedBox(height: 16),
+            FilledButton(
+              onPressed: _saving ? null : _save,
+              child: _saving
+                  ? const SizedBox(
+                      height: 18,
+                      width: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2))
+                  : const Text('Save'),
+            ),
+          ]),
+    );
+  }
+}
+// ===== category_editor_sheet.dart — END =====

--- a/travel_planner_app/lib/screens/monthly/txn_editor_sheet.dart
+++ b/travel_planner_app/lib/screens/monthly/txn_editor_sheet.dart
@@ -1,0 +1,146 @@
+// ===== txn_editor_sheet.dart — START =====
+// Description: Modal to add monthly transactions (salary/expense).
+
+import 'package:flutter/material.dart';
+import '../../services/monthly_store.dart';
+import '../../models/monthly_category.dart';
+
+class TxnEditorSheet extends StatefulWidget {
+  final String monthKey;
+  final String type; // 'income' | 'expense'
+  const TxnEditorSheet({super.key, required this.monthKey, required this.type});
+
+  @override
+  State<TxnEditorSheet> createState() => _TxnEditorSheetState();
+}
+
+class _TxnEditorSheetState extends State<TxnEditorSheet> {
+  MonthlyCategory? _selected;
+  final _amountCtrl = TextEditingController();
+  final _noteCtrl = TextEditingController();
+  String _currency = 'EUR';
+  DateTime _date = DateTime.now();
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _amountCtrl.dispose();
+    _noteCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final amount = double.tryParse(_amountCtrl.text.replaceAll(',', '.')) ?? 0;
+    if (_selected == null || amount <= 0) return;
+    setState(() => _saving = true);
+    await MonthlyStore.instance.addTxn(
+      monthKey: widget.monthKey,
+      categoryId: _selected!.id,
+      amount: amount,
+      currency: _currency,
+      note: _noteCtrl.text.trim(),
+      date: _date,
+      type: widget.type,
+    );
+    if (mounted) Navigator.pop(context, true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cats = MonthlyStore.instance
+        .categoriesFor(widget.monthKey, type: widget.type, parentId: null);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+      child: SingleChildScrollView(
+        child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Add ${widget.type}',
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<MonthlyCategory>(
+                value: _selected,
+                items: [
+                  for (final c in cats) ...[
+                    DropdownMenuItem(value: c, child: Text(c.name)),
+                    for (final s in MonthlyStore.instance
+                        .categoriesFor(widget.monthKey,
+                            type: widget.type, parentId: c.id))
+                      DropdownMenuItem(
+                          value: s,
+                          child: Padding(
+                              padding: const EdgeInsets.only(left: 12),
+                              child: Text('↳ ${s.name}'))),
+                  ]
+                ],
+                onChanged: (v) => setState(() => _selected = v),
+                decoration: const InputDecoration(
+                    labelText: 'Category / Sub-category'),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _amountCtrl,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                decoration: const InputDecoration(labelText: 'Amount'),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _noteCtrl,
+                decoration:
+                    const InputDecoration(labelText: 'Note (optional)'),
+              ),
+              const SizedBox(height: 8),
+              Row(children: [
+                Expanded(
+                  child: DropdownButtonFormField<String>(
+                    value: _currency,
+                    items: const [
+                      DropdownMenuItem(value: 'EUR', child: Text('EUR')),
+                      DropdownMenuItem(value: 'INR', child: Text('INR')),
+                      DropdownMenuItem(value: 'PLN', child: Text('PLN')),
+                      DropdownMenuItem(value: 'USD', child: Text('USD')),
+                    ],
+                    onChanged: (v) => setState(() => _currency = v ?? 'EUR'),
+                    decoration: const InputDecoration(labelText: 'Currency'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: InkWell(
+                    onTap: () async {
+                      final now = DateTime.now();
+                      final picked = await showDatePicker(
+                        context: context,
+                        initialDate: _date,
+                        firstDate: DateTime(now.year - 3),
+                        lastDate: DateTime(now.year + 3),
+                      );
+                      if (picked != null) setState(() => _date = picked);
+                    },
+                    child: InputDecorator(
+                      decoration: const InputDecoration(labelText: 'Date'),
+                      child: Text(
+                          '${_date.year}-${_date.month.toString().padLeft(2, '0')}-${_date.day.toString().padLeft(2, '0')}',
+                          ),
+                    ),
+                  ),
+                ),
+              ]),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: _saving ? null : _save,
+                child: _saving
+                    ? const SizedBox(
+                        height: 18,
+                        width: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2))
+                    : const Text('Save'),
+              ),
+            ]),
+      ),
+    );
+  }
+}
+// ===== txn_editor_sheet.dart — END =====

--- a/travel_planner_app/lib/services/monthly_store.dart
+++ b/travel_planner_app/lib/services/monthly_store.dart
@@ -1,36 +1,114 @@
-// services/monthly_store.dart
-// ▷ MonthlyStore start
-import 'dart:convert';
-import 'package:shared_preferences/shared_preferences.dart';
+// ===== monthly_store.dart — START =====
+// Description: Local store for monthly categories & transactions (Hive).
+// Usage: MonthlyStore.instance.*
+
+import 'package:hive/hive.dart';
+import 'package:uuid/uuid.dart';
+import '../models/monthly_category.dart';
 import '../models/monthly_txn.dart';
 
-String monthKeyOf(DateTime d) => '${d.year}-${d.month.toString().padLeft(2, '0')}';
-
 class MonthlyStore {
-  static String _k(String monthKey) => 'monthly_txns_$monthKey';
+  MonthlyStore._();
+  static final MonthlyStore instance = MonthlyStore._();
 
-  static Future<List<MonthlyTxn>> all(String monthKey) async {
-    final p = await SharedPreferences.getInstance();
-    final s = p.getString(_k(monthKey));
-    if (s == null || s.isEmpty) return <MonthlyTxn>[];
-    final list = (jsonDecode(s) as List).cast<Map<String, dynamic>>();
-    return list.map(MonthlyTxn.fromJson).toList();
+  static const _catBoxName = 'monthly_categories';
+  static const _txnBoxName = 'monthly_txns';
+
+  Future<void> init() async {
+    if (!Hive.isAdapterRegistered(41)) {
+      Hive.registerAdapter(MonthlyCategoryAdapter());
+    }
+    if (!Hive.isAdapterRegistered(42)) {
+      Hive.registerAdapter(MonthlyTxnAdapter());
+    }
+    await Hive.openBox<MonthlyCategory>(_catBoxName);
+    await Hive.openBox<MonthlyTxn>(_txnBoxName);
   }
 
-  static Future<void> _save(String monthKey, List<MonthlyTxn> list) async {
-    final p = await SharedPreferences.getInstance();
-    await p.setString(_k(monthKey), jsonEncode(list.map((e) => e.toJson()).toList()));
+  Box<MonthlyCategory> get _catBox => Hive.box<MonthlyCategory>(_catBoxName);
+  Box<MonthlyTxn> get _txnBox => Hive.box<MonthlyTxn>(_txnBoxName);
+  final _uuid = const Uuid();
+
+  // 👇 NEW: Category CRUD
+  Future<MonthlyCategory> addCategory({
+    required String name,
+    required String monthKey,
+    required String type, // 'income' | 'expense'
+    String? parentId,
+  }) async {
+    final c = MonthlyCategory(
+      id: _uuid.v4(),
+      name: name.trim(),
+      monthKey: monthKey,
+      type: type,
+      parentId: parentId,
+    );
+    await _catBox.put(c.id, c);
+    return c;
   }
 
-  static Future<void> add(String monthKey, MonthlyTxn txn) async {
-    final list = await all(monthKey);
-    final next = [...list.where((t) => t.id != txn.id), txn];
-    await _save(monthKey, next);
+  Future<void> renameCategory(String id, String newName) async {
+    final c = _catBox.get(id);
+    if (c == null) return;
+    c.name = newName.trim();
+    await c.save();
   }
 
-  static Future<void> delete(String monthKey, String id) async {
-    final list = await all(monthKey);
-    await _save(monthKey, list.where((t) => t.id != id).toList());
+  Future<void> deleteCategory(String id) async {
+    // also delete its sub-categories + orphan txns
+    final subs =
+        _catBox.values.where((x) => x.parentId == id).map((x) => x.id).toSet();
+    await _catBox.deleteAll(subs);
+    await _txnBox.deleteAll(_txnBox.values
+        .where((t) => t.categoryId == id || subs.contains(t.categoryId))
+        .map((t) => t.id));
+    await _catBox.delete(id);
+  }
+
+  List<MonthlyCategory> categoriesFor(String monthKey,
+      {String? type, String? parentId}) {
+    return _catBox.values
+        .where((c) =>
+            c.monthKey == monthKey &&
+            (type == null || c.type == type) &&
+            (parentId == c.parentId))
+        .toList()
+      ..sort((a, b) =>
+          a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+  }
+
+  // 👇 NEW: Transactions
+  Future<MonthlyTxn> addTxn({
+    required String monthKey,
+    required String categoryId,
+    required double amount,
+    required String currency,
+    String note = '',
+    DateTime? date,
+    required String type, // 'income' | 'expense'
+  }) async {
+    final t = MonthlyTxn(
+      id: _uuid.v4(),
+      monthKey: monthKey,
+      categoryId: categoryId,
+      amount: amount,
+      currency: currency,
+      note: note,
+      date: date ?? DateTime.now(),
+      type: type,
+    );
+    await _txnBox.put(t.id, t);
+    return t;
+  }
+
+  Future<void> deleteTxn(String id) async => _txnBox.delete(id);
+
+  List<MonthlyTxn> txnsFor(String monthKey) {
+    final list = _txnBox.values
+        .where((t) => t.monthKey == monthKey)
+        .toList()
+      ..sort((a, b) => b.date.compareTo(a.date));
+    return list;
   }
 }
-// ◀ MonthlyStore end
+// ===== monthly_store.dart — END =====


### PR DESCRIPTION
## Summary
- add Hive models for monthly categories and transactions
- implement MonthlyStore for CRUD on categories and txns
- wire up UI sheets and list rendering for categories and recent transactions

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6acbd5e388327b7457f3f57b3752b