### PR TITLE
Thread section type through category tiles

### DIFF
--- a/travel_planner_app/lib/models/monthly_category.dart
+++ b/travel_planner_app/lib/models/monthly_category.dart
@@ -93,4 +93,13 @@ class MonthlyCategory {
         if (parentId != null) 'parentId': parentId,
       };
 }
+
+// 👇 NEW: MonthlyCategory.type — optional convenience
+extension MonthlyCategoryType on MonthlyCategory {
+  String get type {
+    final n = (name).toLowerCase();
+    if (n.contains('salary') || n.contains('income')) return 'income';
+    return 'expense';
+  }
+}
 // ===== monthly_category.dart — END =====

--- a/travel_planner_app/lib/screens/monthly_budget_screen.dart
+++ b/travel_planner_app/lib/screens/monthly_budget_screen.dart
@@ -261,12 +261,18 @@ class _MonthlyBudgetScreenState extends State<MonthlyBudgetScreen> {
                       if (incomeCats.isNotEmpty)
                         Text('Income', style: Theme.of(context).textTheme.labelLarge),
                       for (final c in incomeCats)
-                        _CategoryTile(category: c, monthKey: _monthKey),
+                        _CategoryTile(
+                            category: c,
+                            monthKey: _monthKey,
+                            sectionType: 'income'),
                       const SizedBox(height: 8),
                       if (expenseCats.isNotEmpty)
                         Text('Expenses', style: Theme.of(context).textTheme.labelLarge),
                       for (final c in expenseCats)
-                        _CategoryTile(category: c, monthKey: _monthKey),
+                        _CategoryTile(
+                            category: c,
+                            monthKey: _monthKey,
+                            sectionType: 'expense'),
                       const SizedBox(height: 16),
                       Text('Recent transactions', style: Theme.of(context).textTheme.titleSmall),
                       const SizedBox(height: 8),
@@ -423,12 +429,18 @@ class _BudgetRow extends StatelessWidget {
 class _CategoryTile extends StatelessWidget {
   final MonthlyCategory category;
   final String monthKey;
-  const _CategoryTile({required this.category, required this.monthKey});
+  final String sectionType;
+
+  const _CategoryTile({
+    required this.category,
+    required this.monthKey,
+    required this.sectionType,
+  });
 
   @override
   Widget build(BuildContext context) {
     final subs = MonthlyStore.instance
-        .categoriesFor(monthKey, type: category.type, parentId: category.id);
+        .categoriesFor(monthKey, type: sectionType, parentId: category.id);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -444,7 +456,7 @@ class _CategoryTile extends StatelessWidget {
                 context: context,
                 isScrollControlled: true,
                 builder: (_) => CategoryEditorSheet(
-                    monthKey: monthKey, type: category.type, parent: category),
+                    monthKey: monthKey, type: sectionType, parent: category),
               );
               (context as Element).markNeedsBuild();
             },


### PR DESCRIPTION
## Summary
- Pass explicit section type when building category tiles to avoid relying on model getters
- Add convenience `type` getter for `MonthlyCategory`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c862a8508327986418a1aa0e83d2