### PR TITLE
fix addTxn kind signature and default subcategory planned

### DIFF
--- a/travel_planner_app/lib/screens/monthly/txn_editor_sheet.dart
+++ b/travel_planner_app/lib/screens/monthly/txn_editor_sheet.dart
@@ -40,7 +40,7 @@ class _TxnEditorSheetState extends State<TxnEditorSheet> {
       currency: _currency,
       note: _noteCtrl.text.trim(),
       date: _date,
-      type: widget.type,
+      kind: widget.type,
     );
     if (mounted) Navigator.pop(context, true);
   }

--- a/travel_planner_app/lib/services/monthly_store.dart
+++ b/travel_planner_app/lib/services/monthly_store.dart
@@ -71,19 +71,23 @@ class MonthlyStore {
   /// Add/Upsert a monthly transaction (income or expense)
   Future<void> addTxn({
     required String monthKey,
-    required MonthlyTxnKind kind, // income | expense
     required String currency,
     required double amount,
     String? categoryId,
     String? subCategoryId,
     String? note,
     DateTime? date,
+    required String kind, // 'income' | 'expense'
   }) async {
     final now = date ?? DateTime.now();
     final list = await MonthlyStore.all(monthKey);
+    final kindEnum = (kind.toLowerCase() == 'income')
+        ? MonthlyTxnKind.income
+        : MonthlyTxnKind.expense;
+
     final item = MonthlyTxn(
       id: 'txn-\${now.microsecondsSinceEpoch}',
-      kind: kind,
+      kind: kindEnum,
       currency: currency.toUpperCase(),
       amount: amount,
       categoryId: categoryId,
@@ -180,10 +184,14 @@ class MonthlyStore {
       final next = list.map((c) {
         if (c.id == parentId) {
           return c.copyWith(
-              subs: [...c.subs, MonthlySubCategory(
-                id: 'sub-\${DateTime.now().microsecondsSinceEpoch}',
-                name: name.trim(),
-              )]);
+              subs: [
+            ...c.subs,
+            MonthlySubCategory(
+              id: 'sub-\${DateTime.now().microsecondsSinceEpoch}',
+              name: name.trim(),
+              planned: 0.0,
+            )
+          ]);
         }
         return c;
       }).toList();


### PR DESCRIPTION
## Summary
- Map string-based `kind` to `MonthlyTxnKind` in `MonthlyStore.addTxn`
- Default new sub-categories to `planned: 0.0`
- Use new `kind` param when adding transactions from the sheet

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d34b8b0483279911ed2f6ad4a529