### PR TITLE
Add persistent JWT auth headers and token exchange flow

### DIFF
--- a/travel_planner_app/lib/services/auth_service.dart
+++ b/travel_planner_app/lib/services/auth_service.dart
@@ -1,8 +1,14 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
 class AuthService {
+  AuthService({required this.baseUrl});
+
+  final String baseUrl;
   final GoogleSignIn _google = GoogleSignIn(scopes: ['email', 'profile']);
 
   Future<String?> signInWithGoogleIdToken() async {
@@ -22,5 +28,25 @@ class AuthService {
     );
     // Depending on configuration you might get identityToken or authorizationCode
     return (idToken: res.identityToken, authCode: res.authorizationCode);
+  }
+
+  // 👇 NEW: exchange ID token -> API JWT and persist
+  Future<void> exchangeAndStoreToken({
+    required String provider, // 'google' | 'apple'
+    required String idToken,
+  }) async {
+    final url = Uri.parse('$baseUrl/auth/exchange');
+    final res = await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'provider': provider, 'idToken': idToken}),
+    );
+    if (res.statusCode != 200) {
+      throw Exception('Auth exchange failed: ${res.statusCode} ${res.body}');
+    }
+    final data = jsonDecode(res.body) as Map<String, dynamic>;
+    final p = await SharedPreferences.getInstance();
+    await p.setString('api_jwt', data['token'] as String);
+    await p.setString('user_email', data['email'] as String? ?? '');
   }
 }

--- a/travel_planner_app/lib/services/outbox_service.dart
+++ b/travel_planner_app/lib/services/outbox_service.dart
@@ -63,7 +63,7 @@ class OutboxService {
   /// Returns number of operations sent successfully.
   static Future<int> flush({
     required Uri Function(String path) urlFor,                // e.g. (p) => Uri.parse('$baseUrl$p')
-    required Map<String, String> Function(bool json) headers, // e.g. api.headers
+    required Future<Map<String, String>> Function(bool json) headers, // e.g. api.headers
     Duration perRequestTimeout = const Duration(seconds: 7),
   }) async {
     var list = await _load();
@@ -74,7 +74,7 @@ class OutboxService {
       final op = list[i];
       try {
         final uri = urlFor(op.path);
-        final h = headers(true);
+        final h = await headers(true);
         http.Response res;
         switch (op.method) {
           case 'POST':


### PR DESCRIPTION
## Summary
- load JWT from SharedPreferences for all API calls
- exchange Firebase/Apple tokens for JWT and persist
- update sign-in and outbox to use async auth headers

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e76a4b8083278a3fa6ae96cd9cf6