### PR TITLE
Ensure API JWT exchange and add whoAmI check

### DIFF
--- a/travel_planner_app/lib/services/api_service.dart
+++ b/travel_planner_app/lib/services/api_service.dart
@@ -50,6 +50,13 @@ class ApiService {
   // expose headers for outbox
   Future<Map<String, String>> headers(bool json) => _authHeaders();
 
+  // Debug: verify backend sees our JWT
+  Future<Map<String, dynamic>> whoAmI() async {
+    final headers = await _authHeaders();
+    final res = await http.get(Uri.parse('$baseUrl/auth/me'), headers: headers);
+    return jsonDecode(res.body) as Map<String, dynamic>;
+  }
+
   // -----------------------------
   // Trips
   // -----------------------------


### PR DESCRIPTION
## Summary
- Provide whoAmI request to verify backend sees Authorization header
- Auth service exchanges ID tokens for API JWT and saves token/email in SharedPreferences

## Testing
- `dart format lib/services/api_service.dart lib/services/auth_service.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a728fcbdc88327abc40097c8582ca5