### PR TITLE
feat: add auth headers and safe URL join

### DIFF
--- a/travel_planner_app/lib/services/auth_service.dart
+++ b/travel_planner_app/lib/services/auth_service.dart
@@ -9,6 +9,13 @@ class AuthService {
   AuthService({required this.baseUrl});
 
   final String baseUrl;
+
+  String _u(String path) {
+    final b = baseUrl.endsWith('/') ? baseUrl.substring(0, baseUrl.length - 1) : baseUrl;
+    final p = path.startsWith('/') ? path.substring(1) : path;
+    return '$b/$p';
+  }
+
   final GoogleSignIn _google = GoogleSignIn(scopes: ['email', 'profile']);
 
   Future<String?> signInWithGoogleIdToken() async {
@@ -35,7 +42,7 @@ class AuthService {
     required String provider, // 'google' | 'apple'
     required String idToken,
   }) async {
-    final url = Uri.parse('$baseUrl/auth/exchange');
+    final url = Uri.parse(_u('auth/exchange'));
     final res = await http.post(
       url,
       headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
## Summary
- ensure API requests include bearer token from SharedPreferences
- add safe `_u` URL join helper and use it for all endpoints
- store API JWT after auth exchange and reuse for authenticated calls

## Testing
- `dart format lib/services/api_service.dart lib/services/auth_service.dart` *(fails: command not found)*
- `flutter format lib/services/api_service.dart lib/services/auth_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a754941520832790d08d764f0043b5