### PR TITLE
feat: gate API calls until auth token available

### DIFF
--- a/travel_planner_app/lib/screens/budgets_screen.dart
+++ b/travel_planner_app/lib/screens/budgets_screen.dart
@@ -20,7 +20,7 @@ class BudgetsScreen extends StatefulWidget {
 }
 
 class _BudgetsScreenState extends State<BudgetsScreen> with TickerProviderStateMixin {
-  late Future<List<Budget>> _future;
+  Future<List<Budget>> _future = Future.value(<Budget>[]);
   String _home = TripStorageService.getHomeCurrency();
 
   // Budgets knownTripIds fields start
@@ -36,8 +36,24 @@ class _BudgetsScreenState extends State<BudgetsScreen> with TickerProviderStateM
   @override
   void initState() {
     super.initState();
-    _future = widget.api.fetchBudgetsOrCache();
-    _loadTripIds();
+    () async {
+      try {
+        await widget.api.waitForToken();
+        final fut = widget.api.fetchBudgetsOrCache();
+        if (mounted) {
+          setState(() {
+            _future = fut;
+          });
+          _loadTripIds();
+        }
+      } catch (e) {
+        if (mounted) {
+          setState(() {
+            _future = Future.error(e);
+          });
+        }
+      }
+    }();
   }
 
 // Budgets _refresh sync start

--- a/travel_planner_app/lib/screens/dashboard_screen.dart
+++ b/travel_planner_app/lib/screens/dashboard_screen.dart
@@ -98,6 +98,7 @@ class _DashboardScreenState extends State<DashboardScreen> with WidgetsBindingOb
 
   // 👇 NEW: boot sequence start
   Future<void> _boot() async {
+    await widget.api.waitForToken();
     await _ensureActiveTrip();
     await _loadLocal();            // will recalc + then update home (see patch below)
     await _loadTripBudgetOverride();

--- a/travel_planner_app/lib/screens/group_balance_screen.dart
+++ b/travel_planner_app/lib/screens/group_balance_screen.dart
@@ -23,7 +23,7 @@ class GroupBalanceScreen extends StatefulWidget {
 }
 
 class _GroupBalanceScreenState extends State<GroupBalanceScreen> {
-  late Future<List<BalanceRow>> _future;
+  Future<List<BalanceRow>> _future = Future.value(<BalanceRow>[]);
   List<BalanceRow> _rows = [];
 
   @override
@@ -33,6 +33,7 @@ class _GroupBalanceScreenState extends State<GroupBalanceScreen> {
   }
 
   Future<List<BalanceRow>> _load() async {
+    await widget.api.waitForToken();
     final rows = await widget.api.fetchGroupBalances(widget.tripId);
     _rows = rows;
     return rows;

--- a/travel_planner_app/lib/screens/monthly_budget_screen.dart
+++ b/travel_planner_app/lib/screens/monthly_budget_screen.dart
@@ -22,14 +22,20 @@ class MonthlyBudgetScreen extends StatefulWidget {
 class _MonthlyBudgetScreenState extends State<MonthlyBudgetScreen> {
   late DateTime _month;
   // 👇 NEW: change budgets list to EnvelopeVM
-  late Future<MonthlyBudgetSummary> _summaryFut;
-  late Future<List<EnvelopeVM>> _budgetsFut;
+  Future<MonthlyBudgetSummary> _summaryFut =
+      Future.value(MonthlyBudgetSummary(currency: '', totalBudgeted: 0, totalSpent: 0));
+  Future<List<EnvelopeVM>> _budgetsFut = Future.value(<EnvelopeVM>[]);
 
   @override
   void initState() {
     super.initState();
     _month = DateTime(DateTime.now().year, DateTime.now().month, 1);
-    _load();
+    () async {
+      try {
+        await widget.api.waitForToken();
+        if (mounted) setState(_load);
+      } catch (_) {}
+    }();
   }
 
   // 👇 NEW: wire to the new ApiService methods

--- a/travel_planner_app/lib/screens/monthly_envelopes_screen.dart
+++ b/travel_planner_app/lib/screens/monthly_envelopes_screen.dart
@@ -41,6 +41,7 @@ class _MonthlyEnvelopesScreenState extends State<MonthlyEnvelopesScreen> {
 
   Future<void> _load() async {
     setState(() => _loading = true);
+    await widget.api.waitForToken();
     final budgets = await widget.api.fetchBudgetsOrCache();
     _allBudgets = budgets;
 

--- a/travel_planner_app/lib/screens/monthly_overview_screen.dart
+++ b/travel_planner_app/lib/screens/monthly_overview_screen.dart
@@ -13,7 +13,8 @@ class MonthlyOverviewScreen extends StatefulWidget {
 
 class _MonthlyOverviewScreenState extends State<MonthlyOverviewScreen> {
   DateTime _month = DateTime(DateTime.now().year, DateTime.now().month);
-  late Future<_MonthlyData> _future;
+  Future<_MonthlyData> _future = Future.value(
+      _MonthlyData(month: DateTime.now(), categories: const [], totalBudgeted: 0, totalSpent: 0));
 
   @override
   void initState() {
@@ -22,6 +23,7 @@ class _MonthlyOverviewScreenState extends State<MonthlyOverviewScreen> {
   }
 
   Future<_MonthlyData> _load() async {
+    await widget.api.waitForToken();
     // 1) Fetch all budgets (monthly + trip)
     final budgets = await widget.api.fetchBudgetsOrCache();
     final monthly = budgets.where((b) => b.kind == BudgetKind.monthly).toList();


### PR DESCRIPTION
## Summary
- add safe URL joiner and strict auth headers in ApiService
- introduce waitForToken helper
- await auth token before fetching data in key screens

## Testing
- `dart format travel_planner_app/lib/services/api_service.dart travel_planner_app/lib/screens/budgets_screen.dart travel_planner_app/lib/screens/expenses_screen.dart travel_planner_app/lib/screens/trip_selection_screen.dart travel_planner_app/lib/screens/group_balance_screen.dart travel_planner_app/lib/screens/dashboard_screen.dart travel_planner_app/lib/screens/monthly_budget_screen.dart travel_planner_app/lib/screens/monthly_envelopes_screen.dart travel_planner_app/lib/screens/monthly_overview_screen.dart` (fails: command not found)
- `sudo apt-get install -y dart` (fails: Unable to locate package dart)
- `sudo apt-get install -y flutter` (fails: Unable to locate package flutter)
- `flutter test` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68a75ad32ba083279c7861779b8ddd91