### PR TITLE
Add dev login with JWT headers and who-am-I check

### DIFF
--- a/travel_planner_app/lib/main.dart
+++ b/travel_planner_app/lib/main.dart
@@ -8,7 +8,6 @@ import 'services/trip_storage_service.dart';
 import 'services/hive_migrations.dart';
 import 'services/monthly_store.dart';
 
-
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
@@ -25,13 +24,7 @@ Future<void> main() async {
   // Trip storage init
   await TripStorageService.init();
 
-  // Read API base from --dart-define (with safe default)
-  const base = String.fromEnvironment(
-    'API_BASE_URL',
-    defaultValue: 'https://travel-planner-api-latest.onrender.com',
-  );
-
-  final api = ApiService(baseUrl: base);
+  final api = ApiService();
 
   runApp(TravelPlannerApp(api: api));
 }

--- a/travel_planner_app/lib/screens/sign_in_screen.dart
+++ b/travel_planner_app/lib/screens/sign_in_screen.dart
@@ -64,6 +64,31 @@ class _SignInScreenState extends State<SignInScreen> {
               icon: const Icon(Icons.apple),
               label: const Text('Continue with Apple'),
             ),
+            const SizedBox(height: 12),
+            // 👇 NEW: Dev Sign-in button (issues jwt via /auth/dev, then calls /auth/me)
+            // dev sign-in button start
+            ElevatedButton(
+              onPressed: _busy
+                  ? null
+                  : () async {
+                      try {
+                        await widget.api.loginDev(email: 'rahul@example.com');
+                        final me = await widget.api.getMe();
+                        final email = me['email'] ?? '(no email)';
+                        if (!context.mounted) return;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text('Signed in as $email')),
+                        );
+                      } catch (e) {
+                        if (!context.mounted) return;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text('Dev sign-in failed: $e')),
+                        );
+                      }
+                    },
+              child: const Text('Dev Sign-in'),
+            ),
+            // dev sign-in button end
             const SizedBox(height: 20),
             if (_busy) const CircularProgressIndicator(),
           ],


### PR DESCRIPTION
## Summary
- support platform-aware base URL and in-memory JWT with debug logging
- add shared Authorization headers, dev login, and /auth/me call
- expose Dev Sign-in button to verify authentication

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b094d0786483279a2f348422bd8ba1